### PR TITLE
Add mappings in generated Rust code to eliminate some boilerplates and improve safety

### DIFF
--- a/generators/rust-oo-bindgen/src/conversion.rs
+++ b/generators/rust-oo-bindgen/src/conversion.rs
@@ -2,6 +2,7 @@ use oo_bindgen::formatting::*;
 use oo_bindgen::native_enum::*;
 use oo_bindgen::native_function::*;
 use oo_bindgen::native_struct::*;
+use oo_bindgen::callback::*;
 
 pub(crate) trait RustType {
     fn as_rust_type(&self) -> String;
@@ -229,37 +230,35 @@ impl RustStruct for NativeStructHandle {
 }
 
 pub(crate) trait RustStructField {
-    /*fn as_rust_type(&self) -> String;
-    fn as_c_type(&self) -> String;*/
     fn requires_lifetime_annotation(&self) -> bool;
 }
 
 impl RustStructField for NativeStructElement {
-    /*fn as_rust_type(&self) -> String {
-        let mut result = format!("{}", self.element_type.as_rust_type());
-        if let Type::Iterator(handle) = &self.element_type {
-            if handle.has_lifetime_annotation {
-                result.push_str("<'a>");
-            }
-        }
-        result
-    }
-
-    fn as_c_type(&self) -> String {
-        let mut result = format!("{}", self.element_type.as_c_type());
-        if let Type::Iterator(handle) = &self.element_type {
-            if handle.has_lifetime_annotation {
-                result.push_str("<'a>");
-            }
-        }
-        result
-    }*/
-
     fn requires_lifetime_annotation(&self) -> bool {
         if let Type::Iterator(handle) = &self.element_type {
             handle.has_lifetime_annotation
         } else {
             false
         }
+    }
+}
+
+pub(crate) trait RustCallbackFunction {
+    fn requires_lifetime_annotation(&self) -> bool;
+}
+
+impl RustCallbackFunction for CallbackFunction {
+    fn requires_lifetime_annotation(&self) -> bool {
+        for param in &self.parameters {
+            if let CallbackParameter::Parameter(param) = param {
+                if let Type::Iterator(handle) = &param.param_type {
+                    if handle.has_lifetime_annotation {
+                        return true
+                    }
+                }
+            }
+        }
+
+        false
     }
 }

--- a/generators/rust-oo-bindgen/src/conversion.rs
+++ b/generators/rust-oo-bindgen/src/conversion.rs
@@ -1,0 +1,151 @@
+use oo_bindgen::formatting::*;
+use oo_bindgen::native_enum::*;
+use oo_bindgen::native_function::*;
+use crate::formatting::*;
+
+pub trait RustType {
+    fn as_rust_type(&self) -> String;
+    fn as_c_type(&self) -> String;
+    fn conversion(&self) -> Option<Box<dyn TypeConverter>>;
+}
+
+impl RustType for Type {
+    fn as_rust_type(&self) -> String {
+        match self {
+            Type::Bool => "bool".to_string(),
+            Type::Uint8 => "u8".to_string(),
+            Type::Sint8 => "i8".to_string(),
+            Type::Uint16 => "u16".to_string(),
+            Type::Sint16 => "i16".to_string(),
+            Type::Uint32 => "u32".to_string(),
+            Type::Sint32 => "i32".to_string(),
+            Type::Uint64 => "u64".to_string(),
+            Type::Sint64 => "i64".to_string(),
+            Type::Float => "f32".to_string(),
+            Type::Double => "f64".to_string(),
+            Type::String => "*const std::os::raw::c_char".to_string(),
+            Type::Struct(handle) => format!("{}", handle.name()),
+            Type::StructRef(handle) => format!("*const {}", handle.name),
+            Type::Enum(handle) => format!("{}", handle.name),
+            Type::ClassRef(handle) => format!("*mut crate::{}", handle.name),
+            Type::Interface(handle) => format!("{}", handle.name),
+            Type::OneTimeCallback(handle) => format!("{}", handle.name),
+            Type::Iterator(handle) => format!("*mut crate::{}", handle.name()),
+            Type::Collection(handle) => format!("*mut crate::{}", handle.name()),
+            Type::Duration(mapping) => match mapping {
+                DurationMapping::Milliseconds | DurationMapping::Seconds => "u64".to_string(),
+                DurationMapping::SecondsFloat => "f32".to_string(),
+            },
+        }
+    }
+
+    fn as_c_type(&self) -> String {
+        match self {
+            Type::Bool => "bool".to_string(),
+            Type::Uint8 => "u8".to_string(),
+            Type::Sint8 => "i8".to_string(),
+            Type::Uint16 => "u16".to_string(),
+            Type::Sint16 => "i16".to_string(),
+            Type::Uint32 => "u32".to_string(),
+            Type::Sint32 => "i32".to_string(),
+            Type::Uint64 => "u64".to_string(),
+            Type::Sint64 => "i64".to_string(),
+            Type::Float => "f32".to_string(),
+            Type::Double => "f64".to_string(),
+            Type::String => "*const std::os::raw::c_char".to_string(),
+            Type::Struct(handle) => format!("{}", handle.name()),
+            Type::StructRef(handle) => format!("*const {}", handle.name),
+            Type::Enum(handle) => "std::os::raw::c_int".to_string(),
+            Type::ClassRef(handle) => format!("*mut crate::{}", handle.name),
+            Type::Interface(handle) => format!("{}", handle.name),
+            Type::OneTimeCallback(handle) => format!("{}", handle.name),
+            Type::Iterator(handle) => format!("*mut crate::{}", handle.name()),
+            Type::Collection(handle) => format!("*mut crate::{}", handle.name()),
+            Type::Duration(mapping) => match mapping {
+                DurationMapping::Milliseconds | DurationMapping::Seconds => "u64".to_string(),
+                DurationMapping::SecondsFloat => "f32".to_string(),
+            },
+        }
+    }
+
+    fn conversion(&self) -> Option<Box<dyn TypeConverter>> {
+        match self {
+            Type::Bool => None,
+            Type::Uint8 => None,
+            Type::Sint8 => None,
+            Type::Uint16 => None,
+            Type::Sint16 => None,
+            Type::Uint32 => None,
+            Type::Sint32 => None,
+            Type::Uint64 => None,
+            Type::Sint64 => None,
+            Type::Float => None,
+            Type::Double => None,
+            Type::String => None,
+            Type::Struct(_) => None,
+            Type::StructRef(_) => None,
+            Type::Enum(handle) => Some(Box::new(EnumConverter(handle.clone()))),
+            Type::ClassRef(_) => None,
+            Type::Interface(_) => None,
+            Type::OneTimeCallback(_) => None,
+            Type::Iterator(_) => None,
+            Type::Collection(_) => None,
+            Type::Duration(_) => None,
+        }
+    }
+}
+
+pub trait TypeConverter {
+    fn convert_to_c(&self, f: &mut dyn Printer, from: &str, to: &str) -> FormattingResult<()>;
+    fn convert_from_c(
+        &self,
+        f: &mut dyn Printer,
+        from: &str,
+        to: &str,
+    ) -> FormattingResult<()>;
+}
+
+struct EnumConverter(NativeEnumHandle);
+
+impl TypeConverter for EnumConverter {
+    fn convert_to_c(&self, f: &mut dyn Printer, from: &str, to: &str) -> FormattingResult<()> {
+        f.writeln(&format!("{} = match {}", to, from))?;
+        blocked(f, |f| {
+            for variant in self.0.variants {
+                f.writeln(&format!("{}::{} => {},", self.0.name, variant.name, variant.value))?;
+            }
+            Ok(())
+        })?;
+        f.write(";")
+    }
+
+    fn convert_from_c(
+        &self,
+        f: &mut dyn Printer,
+        from: &str,
+        to: &str,
+    ) -> FormattingResult<()> {
+        f.writeln(&format!("{} = match {}", to, from))?;
+        blocked(f, |f| {
+            for variant in self.0.variants {
+                f.writeln(&format!("{} => {}::{},", variant.value, self.0.name, variant.name, ))?;
+            }
+            f.writeln(&format!("_ => panic!(\"{{}} is not a variant of {}\", {}),", self.0.name, from))
+        })?;
+        f.write(";")
+    }
+}
+
+/*pub struct StructField<'a>(&'a Type);
+
+impl<'a> Display for StructField<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", RustType(self.0).as_rust_type())?;
+        if let Type::Iterator(handle) = &self.0 {
+            if handle.has_lifetime_annotation {
+                f.write_str("<'a>")?
+            }
+        }
+        Ok(())
+    }
+}*/

--- a/generators/rust-oo-bindgen/src/conversion.rs
+++ b/generators/rust-oo-bindgen/src/conversion.rs
@@ -6,6 +6,7 @@ use oo_bindgen::native_struct::*;
 pub(crate) trait RustType {
     fn as_rust_type(&self) -> String;
     fn as_c_type(&self) -> String;
+    fn is_copyable(&self) -> bool;
     fn conversion(&self) -> Option<Box<dyn TypeConverter>>;
     fn has_conversion(&self) -> bool {
         self.conversion().is_some()
@@ -33,7 +34,14 @@ impl RustType for Type {
             Type::ClassRef(handle) => format!("*mut crate::{}", handle.name),
             Type::Interface(handle) => format!("{}", handle.name),
             Type::OneTimeCallback(handle) => format!("{}", handle.name),
-            Type::Iterator(handle) => format!("*mut crate::{}", handle.name()),
+            Type::Iterator(handle) => {
+                let lifetime = if handle.has_lifetime_annotation {
+                    "<'a>"
+                } else {
+                    ""
+                };
+                format!("*mut crate::{}{}", handle.name(), lifetime)
+            }
             Type::Collection(handle) => format!("*mut crate::{}", handle.name()),
             Type::Duration(mapping) => match mapping {
                 DurationMapping::Milliseconds | DurationMapping::Seconds => "u64".to_string(),
@@ -56,18 +64,51 @@ impl RustType for Type {
             Type::Float => "f32".to_string(),
             Type::Double => "f64".to_string(),
             Type::String => "*const std::os::raw::c_char".to_string(),
-            Type::Struct(handle) => format!("Native{}", handle.name()),
-            Type::StructRef(handle) => format!("*const Native{}", handle.name),
+            Type::Struct(handle) => handle.name().to_string(),
+            Type::StructRef(handle) => format!("*const {}", handle.name),
             Type::Enum(_) => "std::os::raw::c_int".to_string(),
             Type::ClassRef(handle) => format!("*mut crate::{}", handle.name),
-            Type::Interface(handle) => format!("{}", handle.name),
-            Type::OneTimeCallback(handle) => format!("{}", handle.name),
-            Type::Iterator(handle) => format!("*mut crate::{}", handle.name()),
+            Type::Interface(handle) => handle.name.to_string(),
+            Type::OneTimeCallback(handle) => handle.name.to_string(),
+            Type::Iterator(handle) => {
+                let lifetime = if handle.has_lifetime_annotation {
+                    "<'a>"
+                } else {
+                    ""
+                };
+                format!("*mut crate::{}{}", handle.name(), lifetime)
+            }
             Type::Collection(handle) => format!("*mut crate::{}", handle.name()),
             Type::Duration(mapping) => match mapping {
                 DurationMapping::Milliseconds | DurationMapping::Seconds => "u64".to_string(),
                 DurationMapping::SecondsFloat => "f32".to_string(),
             },
+        }
+    }
+
+    fn is_copyable(&self) -> bool {
+        match self {
+            Type::Bool => true,
+            Type::Uint8 => true,
+            Type::Sint8 => true,
+            Type::Uint16 => true,
+            Type::Sint16 => true,
+            Type::Uint32 => true,
+            Type::Sint32 => true,
+            Type::Uint64 => true,
+            Type::Sint64 => true,
+            Type::Float => true,
+            Type::Double => true,
+            Type::String => true, // Just copying the pointer
+            Type::Struct(_) => false,
+            Type::StructRef(_) => true,
+            Type::Enum(_) => true,
+            Type::ClassRef(_) => true, // Just copying the opaque pointer
+            Type::Interface(_) => false,
+            Type::OneTimeCallback(_) => false,
+            Type::Iterator(_) => true,   // Just copying the pointer
+            Type::Collection(_) => true, // Just copying the pointer
+            Type::Duration(_) => true,
         }
     }
 
@@ -85,7 +126,7 @@ impl RustType for Type {
             Type::Float => None,
             Type::Double => None,
             Type::String => None,
-            Type::Struct(handle) => Some(Box::new(StructConverter(handle.clone()))),
+            Type::Struct(_) => None,
             Type::StructRef(handle) => Some(Box::new(StructRefConverter(handle.clone()))),
             Type::Enum(handle) => Some(Box::new(EnumConverter(handle.clone()))),
             Type::ClassRef(_) => None,
@@ -115,6 +156,14 @@ impl RustType for ReturnType {
         }
     }
 
+    fn is_copyable(&self) -> bool {
+        if let ReturnType::Type(return_type, _) = self {
+            return_type.is_copyable()
+        } else {
+            true
+        }
+    }
+
     fn conversion(&self) -> Option<Box<dyn TypeConverter>> {
         if let ReturnType::Type(return_type, _) = self {
             return_type.conversion()
@@ -126,12 +175,7 @@ impl RustType for ReturnType {
 
 pub(crate) trait TypeConverter {
     fn convert_to_c(&self, f: &mut dyn Printer, from: &str, to: &str) -> FormattingResult<()>;
-    fn convert_from_c(
-        &self,
-        f: &mut dyn Printer,
-        from: &str,
-        to: &str,
-    ) -> FormattingResult<()>;
+    fn convert_from_c(&self, f: &mut dyn Printer, from: &str, to: &str) -> FormattingResult<()>;
 }
 
 struct EnumConverter(NativeEnumHandle);
@@ -141,29 +185,7 @@ impl TypeConverter for EnumConverter {
         f.writeln(&format!("{}{}.into()", to, from))
     }
 
-    fn convert_from_c(
-        &self,
-        f: &mut dyn Printer,
-        from: &str,
-        to: &str,
-    ) -> FormattingResult<()> {
-        f.writeln(&format!("{}{}.into()", to, from))
-    }
-}
-
-struct StructConverter(NativeStructHandle);
-
-impl TypeConverter for StructConverter {
-    fn convert_to_c(&self, f: &mut dyn Printer, from: &str, to: &str) -> FormattingResult<()> {
-        f.writeln(&format!("{}{}.into()", to, from))
-    }
-
-    fn convert_from_c(
-        &self,
-        f: &mut dyn Printer,
-        from: &str,
-        to: &str,
-    ) -> FormattingResult<()> {
+    fn convert_from_c(&self, f: &mut dyn Printer, from: &str, to: &str) -> FormattingResult<()> {
         f.writeln(&format!("{}{}.into()", to, from))
     }
 }
@@ -172,42 +194,48 @@ struct StructRefConverter(NativeStructDeclarationHandle);
 
 impl TypeConverter for StructRefConverter {
     fn convert_to_c(&self, f: &mut dyn Printer, from: &str, to: &str) -> FormattingResult<()> {
-        f.writeln(&format!("{}{}.map_or(std::ptr::null(), |val| val.into() as *const _)", to, from))
+        f.writeln(&format!(
+            "{}{}.map_or(std::ptr::null(), |val| val as *const _)",
+            to, from
+        ))
     }
 
-    fn convert_from_c(
-        &self,
-        f: &mut dyn Printer,
-        from: &str,
-        to: &str,
-    ) -> FormattingResult<()> {
-        f.writeln(&format!("{}{}.as_ref().map(|val| val.into())", to, from))
+    fn convert_from_c(&self, f: &mut dyn Printer, from: &str, to: &str) -> FormattingResult<()> {
+        f.writeln(&format!("{}{}.as_ref()", to, from))
     }
 }
 
 pub(crate) trait RustStruct {
     fn requires_lifetime_annotation(&self) -> bool;
+    fn has_conversion(&self) -> bool;
 }
 
 impl RustStruct for NativeStructHandle {
     fn requires_lifetime_annotation(&self) -> bool {
-        self.elements.iter().any(|e| {
-            if let Type::Iterator(handle) = &e.element_type {
-                handle.has_lifetime_annotation
-            } else {
-                false
+        self.elements
+            .iter()
+            .any(|e| e.requires_lifetime_annotation())
+    }
+
+    fn has_conversion(&self) -> bool {
+        for element in &self.elements {
+            if element.element_type.has_conversion() {
+                return true;
             }
-        })
+        }
+
+        false
     }
 }
 
 pub(crate) trait RustStructField {
-    fn as_rust_type(&self) -> String;
-    fn as_c_type(&self) -> String;
+    /*fn as_rust_type(&self) -> String;
+    fn as_c_type(&self) -> String;*/
+    fn requires_lifetime_annotation(&self) -> bool;
 }
 
 impl RustStructField for NativeStructElement {
-    fn as_rust_type(&self) -> String {
+    /*fn as_rust_type(&self) -> String {
         let mut result = format!("{}", self.element_type.as_rust_type());
         if let Type::Iterator(handle) = &self.element_type {
             if handle.has_lifetime_annotation {
@@ -225,5 +253,13 @@ impl RustStructField for NativeStructElement {
             }
         }
         result
+    }*/
+
+    fn requires_lifetime_annotation(&self) -> bool {
+        if let Type::Iterator(handle) = &self.element_type {
+            handle.has_lifetime_annotation
+        } else {
+            false
+        }
     }
 }

--- a/generators/rust-oo-bindgen/src/conversion.rs
+++ b/generators/rust-oo-bindgen/src/conversion.rs
@@ -132,7 +132,7 @@ impl RustType for Type {
             Type::ClassRef(_) => false,
             Type::Interface(_) => false,
             Type::OneTimeCallback(_) => false,
-            Type::Iterator(_) => true,
+            Type::Iterator(handle) => handle.has_lifetime_annotation,
             Type::Collection(_) => false,
             Type::Duration(_) => false,
         }
@@ -158,7 +158,7 @@ impl RustType for Type {
             Type::ClassRef(_) => false,
             Type::Interface(_) => false,
             Type::OneTimeCallback(_) => false,
-            Type::Iterator(_) => true,
+            Type::Iterator(handle) => handle.has_lifetime_annotation,
             Type::Collection(_) => false,
             Type::Duration(_) => false,
         }
@@ -367,22 +367,20 @@ impl RustCallbackFunction for CallbackFunction {
     fn rust_requires_lifetime(&self) -> bool {
         self.parameters.iter().any(|param| {
             if let CallbackParameter::Parameter(param) = param {
-                if param.param_type.rust_requires_lifetime() {
-                    return true;
-                }
+                param.param_type.rust_requires_lifetime()
+            } else {
+                false
             }
-            false
         })
     }
 
     fn c_requires_lifetime(&self) -> bool {
         self.parameters.iter().any(|param| {
             if let CallbackParameter::Parameter(param) = param {
-                if param.param_type.c_requires_lifetime() {
-                    return true;
-                }
+                param.param_type.c_requires_lifetime()
+            } else {
+                false
             }
-            false
         })
     }
 }

--- a/generators/rust-oo-bindgen/src/lib.rs
+++ b/generators/rust-oo-bindgen/src/lib.rs
@@ -377,8 +377,14 @@ impl<'a> RustCodegen<'a> {
                         f.writeln(&format!("{}: *mut std::os::raw::c_void,", name))?
                     }
                     InterfaceElement::CallbackFunction(handle) => {
+                        let lifetime = if handle.requires_lifetime_annotation() {
+                            "for<'a> "
+                        } else {
+                            ""
+                        };
+
                         f.newline()?;
-                        f.write(&format!("{}: Option<extern \"C\" fn(", handle.name))?;
+                        f.write(&format!("{name}: Option<{lifetime}extern \"C\" fn(", name=handle.name, lifetime=lifetime))?;
 
                         f.write(
                             &handle
@@ -440,8 +446,14 @@ impl<'a> RustCodegen<'a> {
                         f.writeln(&format!("{}: *mut std::os::raw::c_void,", name))?
                     }
                     OneTimeCallbackElement::CallbackFunction(handle) => {
+                        let lifetime = if handle.requires_lifetime_annotation() {
+                            "for<'a> "
+                        } else {
+                            ""
+                        };
+
                         f.newline()?;
-                        f.write(&format!("{}: Option<extern \"C\" fn(", handle.name))?;
+                        f.write(&format!("{name}: Option<{lifetime}extern \"C\" fn(", name=handle.name, lifetime=lifetime))?;
 
                         f.write(
                             &handle
@@ -487,8 +499,14 @@ impl<'a> RustCodegen<'a> {
         f.writeln(&format!("impl {}", name))?;
         blocked(f, |f| {
             for callback in callbacks {
+                let lifetime = if callback.requires_lifetime_annotation() {
+                    "<'a>"
+                } else {
+                    ""
+                };
+
                 // Function signature
-                f.writeln(&format!("pub(crate) fn {}(&self, ", callback.name))?;
+                f.writeln(&format!("pub(crate) fn {name}{lifetime}(&self, ", name=callback.name, lifetime=lifetime))?;
                 f.write(
                     &callback
                         .parameters

--- a/generators/rust-oo-bindgen/src/lib.rs
+++ b/generators/rust-oo-bindgen/src/lib.rs
@@ -156,6 +156,7 @@ impl<'a> RustCodegen<'a> {
                 };
 
                 // Accessor
+                f.writeln("#[allow(clippy::needless_lifetimes)]")?;
                 f.writeln(&format!(
                     "pub fn {name}{fn_lifetime}(&{lifetime}self) -> {ampersand}{return_type}",
                     name = element.name,
@@ -191,7 +192,10 @@ impl<'a> RustCodegen<'a> {
                     }
                 })?;
 
+                f.newline()?;
+
                 // Mutator
+                f.writeln("#[allow(clippy::needless_lifetimes)]")?;
                 f.writeln(&format!(
                     "pub fn set_{name}{fn_lifetime}(&{lifetime}mut self, value: {element_type})",
                     name = element.name,
@@ -211,6 +215,8 @@ impl<'a> RustCodegen<'a> {
                         f.writeln(&format!("self.{} = value;", element.name))
                     }
                 })?;
+
+                f.newline()?;
             }
             Ok(())
         })?;
@@ -334,6 +340,7 @@ impl<'a> RustCodegen<'a> {
         f: &mut dyn Printer,
         handle: &NativeFunctionHandle,
     ) -> FormattingResult<()> {
+        f.writeln("#[allow(clippy::missing_safety_doc)]")?;
         f.writeln("#[no_mangle]")?;
         f.writeln(&format!("pub unsafe extern \"C\" fn {}(", handle.name))?;
 

--- a/tests/foo-ffi/src/callback.rs
+++ b/tests/foo-ffi/src/callback.rs
@@ -29,8 +29,8 @@ impl CallbackSource {
         self.callback
             .as_ref()
             .map_or(Duration::from_millis(0), |cb| {
-                cb.on_duration(value.as_millis() as u64)
-                    .map_or(Duration::from_millis(0), Duration::from_millis)
+                cb.on_duration(value)
+                    .map_or(Duration::from_millis(0), |value| value)
             })
     }
 }
@@ -64,9 +64,7 @@ pub unsafe fn cbsource_set_value(cb_source: *mut CallbackSource, value: u32) -> 
     cb_source.set_value(value)
 }
 
-pub unsafe fn cbsource_set_duration(cb_source: *mut CallbackSource, value: u64) -> u64 {
+pub unsafe fn cbsource_set_duration(cb_source: *mut CallbackSource, value: Duration) -> Duration {
     let cb_source = cb_source.as_mut().unwrap();
-    cb_source
-        .set_duration(Duration::from_millis(value))
-        .as_millis() as u64
+    cb_source.set_duration(value)
 }

--- a/tests/foo-ffi/src/collection.rs
+++ b/tests/foo-ffi/src/collection.rs
@@ -36,7 +36,7 @@ pub unsafe fn collection_destroy(col: *mut StringCollection) {
     }
 }
 
-pub unsafe fn collection_add<'a>(col: *mut StringCollection, value: &'a CStr) {
+pub unsafe fn collection_add(col: *mut StringCollection, value: &CStr) {
     if let Some(col) = col.as_mut() {
         let value = value.to_owned();
         col.add(value);

--- a/tests/foo-ffi/src/collection.rs
+++ b/tests/foo-ffi/src/collection.rs
@@ -1,5 +1,4 @@
 use std::ffi::{CStr, CString};
-use std::os::raw::c_char;
 
 pub struct StringCollection {
     values: Vec<CString>,
@@ -37,9 +36,9 @@ pub unsafe fn collection_destroy(col: *mut StringCollection) {
     }
 }
 
-pub unsafe fn collection_add(col: *mut StringCollection, value: *const c_char) {
+pub unsafe fn collection_add<'a>(col: *mut StringCollection, value: &'a CStr) {
     if let Some(col) = col.as_mut() {
-        let value = CStr::from_ptr(value).to_owned();
+        let value = value.to_owned();
         col.add(value);
     }
 }
@@ -52,15 +51,15 @@ pub unsafe fn collection_size(col: *mut StringCollection) -> u32 {
     }
 }
 
-pub unsafe fn collection_get(col: *mut StringCollection, idx: u32) -> *const c_char {
+pub unsafe fn collection_get<'a>(col: *mut StringCollection, idx: u32) -> &'a CStr {
     if let Some(col) = col.as_ref() {
         if let Some(value) = col.values.get(idx as usize) {
-            value.as_ptr()
+            value
         } else {
-            std::ptr::null()
+            CStr::from_ptr(std::ptr::null())
         }
     } else {
-        std::ptr::null()
+        CStr::from_ptr(std::ptr::null())
     }
 }
 
@@ -68,6 +67,6 @@ pub unsafe fn collection_with_reserve_size(col: *mut StringCollection) -> u32 {
     collection_size(col)
 }
 
-pub unsafe fn collection_with_reserve_get(col: *mut StringCollection, idx: u32) -> *const c_char {
+pub unsafe fn collection_with_reserve_get<'a>(col: *mut StringCollection, idx: u32) -> &'a CStr {
     collection_get(col, idx)
 }

--- a/tests/foo-ffi/src/duration.rs
+++ b/tests/foo-ffi/src/duration.rs
@@ -1,16 +1,13 @@
 use std::time::Duration;
 
-pub fn duration_ms_echo(value: u64) -> u64 {
-    let duration = Duration::from_millis(value);
-    duration.as_millis() as u64
+pub fn duration_ms_echo(value: Duration) -> Duration {
+    value
 }
 
-pub fn duration_s_echo(value: u64) -> u64 {
-    let duration = Duration::from_secs(value);
-    duration.as_secs()
+pub fn duration_s_echo(value: Duration) -> Duration {
+    value
 }
 
-pub fn duration_s_float_echo(value: f32) -> f32 {
-    let duration = Duration::from_secs_f32(value);
-    duration.as_secs_f32()
+pub fn duration_s_float_echo(value: Duration) -> Duration {
+    value
 }

--- a/tests/foo-ffi/src/ffi.rs
+++ b/tests/foo-ffi/src/ffi.rs
@@ -1,3 +1,1 @@
-#![allow(clippy::missing_safety_doc)]
-
 include!(concat!(env!("OUT_DIR"), "/ffi.rs"));

--- a/tests/foo-ffi/src/ffi.rs
+++ b/tests/foo-ffi/src/ffi.rs
@@ -1,1 +1,3 @@
+#![allow(clippy::missing_safety_doc)]
+
 include!(concat!(env!("OUT_DIR"), "/ffi.rs"));

--- a/tests/foo-ffi/src/iterator.rs
+++ b/tests/foo-ffi/src/iterator.rs
@@ -17,7 +17,7 @@ impl StringIterator {
 
     fn next(&mut self) {
         match self.iter.next() {
-            Some(val) => self.current = Some(ffi::StringIteratorItem { value: val }),
+            Some(val) => self.current = Some(ffi::StringIteratorItemFields { value: val }.into()),
             None => self.current = None,
         }
     }

--- a/tests/foo-ffi/src/iterator.rs
+++ b/tests/foo-ffi/src/iterator.rs
@@ -35,14 +35,14 @@ pub unsafe fn iterator_destroy(it: *mut StringIterator) {
     }
 }
 
-pub unsafe fn iterator_next(value: *mut StringIterator) -> *const ffi::StringIteratorItem {
+pub unsafe fn iterator_next<'a>(value: *mut StringIterator) -> Option<&'a ffi::StringIteratorItem> {
     if let Some(it) = value.as_mut() {
         it.next();
         match &it.current {
-            Some(val) => val as *const _,
-            None => std::ptr::null(),
+            Some(val) => Some(val),
+            None => None,
         }
     } else {
-        std::ptr::null()
+        None
     }
 }

--- a/tests/foo-ffi/src/iterator.rs
+++ b/tests/foo-ffi/src/iterator.rs
@@ -22,7 +22,7 @@ impl StringIterator {
     }
 }
 
-pub unsafe fn iterator_create<'a>(value: &'a CStr) -> *mut StringIterator {
+pub unsafe fn iterator_create(value: &CStr) -> *mut StringIterator {
     let bytes = value.to_bytes().to_vec();
     let it = Box::new(StringIterator::new(bytes));
     Box::into_raw(it)

--- a/tests/foo-ffi/src/iterator.rs
+++ b/tests/foo-ffi/src/iterator.rs
@@ -1,6 +1,5 @@
 use crate::ffi;
 use std::ffi::CStr;
-use std::os::raw::c_char;
 
 pub struct StringIterator {
     iter: std::vec::IntoIter<u8>,
@@ -17,14 +16,14 @@ impl StringIterator {
 
     fn next(&mut self) {
         match self.iter.next() {
-            Some(val) => self.current = Some(ffi::StringIteratorItemFields { value: val }.into()),
+            Some(val) => self.current = Some(ffi::StringIteratorItemFields { value: val }),
             None => self.current = None,
         }
     }
 }
 
-pub unsafe fn iterator_create(value: *const c_char) -> *mut StringIterator {
-    let bytes = CStr::from_ptr(value).to_bytes().to_vec();
+pub unsafe fn iterator_create<'a>(value: &'a CStr) -> *mut StringIterator {
+    let bytes = value.to_bytes().to_vec();
     let it = Box::new(StringIterator::new(bytes));
     Box::into_raw(it)
 }

--- a/tests/foo-ffi/src/lifetime.rs
+++ b/tests/foo-ffi/src/lifetime.rs
@@ -4,6 +4,6 @@ pub struct IteratorWithLifeTime<'a> {
 
 pub unsafe fn next_value_with_lifetime(
     _it: *mut crate::IteratorWithLifeTime,
-) -> *const crate::ffi::IteratorItem {
-    std::ptr::null()
+) -> Option<&crate::ffi::IteratorItem> {
+    None
 }

--- a/tests/foo-ffi/src/strings.rs
+++ b/tests/foo-ffi/src/strings.rs
@@ -23,12 +23,12 @@ pub unsafe fn string_destroy(string_class: *mut StringClass) {
     }
 }
 
-pub unsafe fn string_echo<'a>(string_class: *mut StringClass, value: &'a CStr) -> &'a CStr {
+pub unsafe fn string_echo(string_class: *mut StringClass, value: &CStr) -> &CStr {
     let mut string_class = string_class.as_mut().unwrap();
     string_class.value = value.to_owned();
     &string_class.value
 }
 
-pub unsafe fn string_length<'a>(value: &'a CStr) -> u32 {
+pub unsafe fn string_length(value: &CStr) -> u32 {
     value.to_string_lossy().len() as u32
 }

--- a/tests/foo-ffi/src/strings.rs
+++ b/tests/foo-ffi/src/strings.rs
@@ -1,5 +1,4 @@
 use std::ffi::{CStr, CString};
-use std::os::raw::c_char;
 
 pub struct StringClass {
     value: CString,
@@ -24,12 +23,12 @@ pub unsafe fn string_destroy(string_class: *mut StringClass) {
     }
 }
 
-pub unsafe fn string_echo(string_class: *mut StringClass, value: *const c_char) -> *const c_char {
+pub unsafe fn string_echo<'a>(string_class: *mut StringClass, value: &'a CStr) -> &'a CStr {
     let mut string_class = string_class.as_mut().unwrap();
-    string_class.value = CStr::from_ptr(value).to_owned();
-    string_class.value.as_ptr()
+    string_class.value = value.to_owned();
+    &string_class.value
 }
 
-pub unsafe fn string_length(value: *const c_char) -> u32 {
-    CStr::from_ptr(value).to_string_lossy().len() as u32
+pub unsafe fn string_length<'a>(value: &'a CStr) -> u32 {
+    value.to_string_lossy().len() as u32
 }

--- a/tests/foo-ffi/src/structure.rs
+++ b/tests/foo-ffi/src/structure.rs
@@ -2,15 +2,15 @@ use crate::ffi;
 
 pub(crate) fn struct_by_value_echo(value: ffi::Structure) -> ffi::Structure {
     {
-        value.interface_value.on_value(&value);
+        value.interface_value.on_value(Some(&value));
     }
     value
 }
 
-pub(crate) unsafe fn struct_by_reference_echo(value: *const ffi::Structure) -> ffi::Structure {
-    let value = std::ptr::read(value);
+pub(crate) unsafe fn struct_by_reference_echo(value: Option<&ffi::Structure>) -> ffi::Structure {
+    let value = std::ptr::read(value.unwrap());
     {
-        value.interface_value.on_value(&value);
+        value.interface_value.on_value(Some(&value));
     }
 
     value

--- a/tests/foo-ffi/src/structure.rs
+++ b/tests/foo-ffi/src/structure.rs
@@ -2,7 +2,7 @@ use crate::ffi;
 
 pub(crate) fn struct_by_value_echo(value: ffi::Structure) -> ffi::Structure {
     {
-        value.interface_value.on_value(Some(&value));
+        value.interface_value().on_value(Some(&value));
     }
     value
 }
@@ -10,7 +10,7 @@ pub(crate) fn struct_by_value_echo(value: ffi::Structure) -> ffi::Structure {
 pub(crate) unsafe fn struct_by_reference_echo(value: Option<&ffi::Structure>) -> ffi::Structure {
     let value = std::ptr::read(value.unwrap());
     {
-        value.interface_value.on_value(Some(&value));
+        value.interface_value().on_value(Some(&value));
     }
 
     value


### PR DESCRIPTION
What was supposed to just be a check of the enums to bypass the undefined behaviour raised in #23 ended up in a large refactoring of the Rust codegen with more powerful mappings to eliminate as much manual labour as possible.

Because some mappings can happen in structs, the solution was to hide the C fields and provide public accessors/mutators to interact with them in a Rusty fashion. To help creating new structs from scratch, a `MyStructFields` (notice the extra "Fields") is generated for each `MyStruct`. This struct has all its Rusty members public and implements `From<MyStructFields> for MyStruct` meaning you can do something like:

```rust
let example: MyStruct = MyStructField {
   foo: MyEnum::bar,
   // ...
}.into();
```

The current mappings are:
- Enums are mapped from `c_int` to `MyEnum`. The conversion makes sure that the enum value is valid and panics if it's not. This is better than the undefined behaviour of current Rust.
- StructRefs are mapped from `*const MyStruct` to `Option<&MyStruct>`. `None` is mapped to `std::ptr::null()`.
- Durations are mapped from `u64`/`f64` to `std::time::Duration`.
- Strings are mapped from `*const c_char` to `&std::ffi::CStr`.

Also, I removed the empty safety comments in the generated code, so we'll need to add a `#![allow(clippy::missing_safety_doc)]` at the beginning of our `ffi.rs` files. For some reason, I cannot put this in the generated file.