### PR TITLE
Better documentation support

### DIFF
--- a/ci-script/Cargo.toml
+++ b/ci-script/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 [dependencies]
 oo-bindgen = { path = "../oo-bindgen" }
 c-oo-bindgen = { path = "../generators/c-oo-bindgen" }
-#dotnet-oo-bindgen = { path = "../generators/dotnet-oo-bindgen" }
+dotnet-oo-bindgen = { path = "../generators/dotnet-oo-bindgen" }
 java-oo-bindgen = { path = "../generators/java-oo-bindgen" }
 clap = "2.33"

--- a/ci-script/Cargo.toml
+++ b/ci-script/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 [dependencies]
 oo-bindgen = { path = "../oo-bindgen" }
 c-oo-bindgen = { path = "../generators/c-oo-bindgen" }
-dotnet-oo-bindgen = { path = "../generators/dotnet-oo-bindgen" }
-java-oo-bindgen = { path = "../generators/java-oo-bindgen" }
+#dotnet-oo-bindgen = { path = "../generators/dotnet-oo-bindgen" }
+#java-oo-bindgen = { path = "../generators/java-oo-bindgen" }
 clap = "2.33"

--- a/ci-script/Cargo.toml
+++ b/ci-script/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 oo-bindgen = { path = "../oo-bindgen" }
 c-oo-bindgen = { path = "../generators/c-oo-bindgen" }
 #dotnet-oo-bindgen = { path = "../generators/dotnet-oo-bindgen" }
-#java-oo-bindgen = { path = "../generators/java-oo-bindgen" }
+java-oo-bindgen = { path = "../generators/java-oo-bindgen" }
 clap = "2.33"

--- a/ci-script/src/lib.rs
+++ b/ci-script/src/lib.rs
@@ -65,10 +65,10 @@ pub fn run(settings: BindingBuilderSettings) {
     }
     /*if run_dotnet || run_all {
         run_builder::<DotnetBindingBuilder>(&settings, run_tests, package_src);
-    }
+    }*/
     if run_java || run_all {
         run_builder::<JavaBindingBuilder>(&settings, run_tests, package_src);
-    }*/
+    }
 }
 
 fn ffi_path() -> PathBuf {
@@ -316,7 +316,7 @@ impl<'a> BindingBuilder<'a> for DotnetBindingBuilder<'a> {
             .unwrap();
         assert!(result.success());
     }
-}
+}*/
 
 struct JavaBindingBuilder<'a> {
     settings: &'a BindingBuilderSettings<'a>,
@@ -398,4 +398,3 @@ impl<'a> BindingBuilder<'a> for JavaBindingBuilder<'a> {
         assert!(result.success());
     }
 }
-*/

--- a/ci-script/src/lib.rs
+++ b/ci-script/src/lib.rs
@@ -63,12 +63,12 @@ pub fn run(settings: BindingBuilderSettings) {
             builder.build_doxygen();
         }
     }
-    if run_dotnet || run_all {
+    /*if run_dotnet || run_all {
         run_builder::<DotnetBindingBuilder>(&settings, run_tests, package_src);
     }
     if run_java || run_all {
         run_builder::<JavaBindingBuilder>(&settings, run_tests, package_src);
-    }
+    }*/
 }
 
 fn ffi_path() -> PathBuf {
@@ -235,7 +235,7 @@ impl<'a> BindingBuilder<'a> for CBindingBuilder<'a> {
         // Already done in build
     }
 }
-
+/*
 struct DotnetBindingBuilder<'a> {
     settings: &'a BindingBuilderSettings<'a>,
     platforms: PlatformLocations,
@@ -398,3 +398,4 @@ impl<'a> BindingBuilder<'a> for JavaBindingBuilder<'a> {
         assert!(result.success());
     }
 }
+*/

--- a/ci-script/src/lib.rs
+++ b/ci-script/src/lib.rs
@@ -63,9 +63,9 @@ pub fn run(settings: BindingBuilderSettings) {
             builder.build_doxygen();
         }
     }
-    /*if run_dotnet || run_all {
+    if run_dotnet || run_all {
         run_builder::<DotnetBindingBuilder>(&settings, run_tests, package_src);
-    }*/
+    }
     if run_java || run_all {
         run_builder::<JavaBindingBuilder>(&settings, run_tests, package_src);
     }
@@ -235,7 +235,7 @@ impl<'a> BindingBuilder<'a> for CBindingBuilder<'a> {
         // Already done in build
     }
 }
-/*
+
 struct DotnetBindingBuilder<'a> {
     settings: &'a BindingBuilderSettings<'a>,
     platforms: PlatformLocations,
@@ -316,7 +316,7 @@ impl<'a> BindingBuilder<'a> for DotnetBindingBuilder<'a> {
             .unwrap();
         assert!(result.success());
     }
-}*/
+}
 
 struct JavaBindingBuilder<'a> {
     settings: &'a BindingBuilderSettings<'a>,

--- a/generators/c-oo-bindgen/src/doc.rs
+++ b/generators/c-oo-bindgen/src/doc.rs
@@ -34,6 +34,8 @@ pub(crate) fn docstring_print(
     for el in docstring.elements() {
         match el {
             DocStringElement::Text(text) => f.write(text)?,
+            DocStringElement::Null => f.write("@p NULL")?,
+            DocStringElement::Iterator => f.write("iterator")?,
             DocStringElement::Reference(reference) => reference_print(f, reference, lib)?,
         }
     }
@@ -51,8 +53,8 @@ fn reference_print(
             f.write(&format!("@p {}", param_name.to_snake_case()))?
         }
         DocReference::Class(class_name) => {
-            let class_name = lib.find_class(class_name).unwrap().declaration();
-            f.write(&format!("@ref {}", class_name.to_type()))?;
+            let handle = lib.find_class(class_name).unwrap().declaration();
+            f.write(&format!("@ref {}", handle.to_type()))?;
         }
         DocReference::ClassMethod(class_name, method_name) => {
             let func_name = &lib
@@ -62,6 +64,20 @@ fn reference_print(
                 .unwrap()
                 .name;
             f.write(&format!("@ref {}", func_name))?;
+        }
+        DocReference::ClassConstructor(class_name) => {
+            let handle = lib.find_class(class_name).unwrap();
+            f.write(&format!(
+                "@ref {}",
+                handle.constructor.as_ref().unwrap().name
+            ))?;
+        }
+        DocReference::ClassDestructor(class_name) => {
+            let handle = lib.find_class(class_name).unwrap();
+            f.write(&format!(
+                "@ref {}",
+                handle.destructor.as_ref().unwrap().name
+            ))?;
         }
         DocReference::Struct(struct_name) => {
             let struct_name = lib.find_struct(struct_name).unwrap().declaration();

--- a/generators/c-oo-bindgen/src/doc.rs
+++ b/generators/c-oo-bindgen/src/doc.rs
@@ -47,7 +47,9 @@ fn reference_print(
     lib: &Library,
 ) -> FormattingResult<()> {
     match reference {
-        DocReference::Param(param_name) => f.write(&param_name.to_snake_case())?,
+        DocReference::Param(param_name) => {
+            f.write(&format!("@p {}", param_name.to_snake_case()))?
+        }
         DocReference::Class(class_name) => {
             let class_name = lib.find_class(class_name).unwrap().declaration();
             f.write(&format!("@ref {}", class_name.to_type()))?;
@@ -75,13 +77,12 @@ fn reference_print(
             f.write(&format!("@ref {}", func_name))?;
         }
         DocReference::StructElement(struct_name, element_name) => {
-            let func_name = &lib
-                .find_struct(struct_name)
-                .unwrap()
-                .find_element(element_name)
-                .unwrap()
-                .name;
-            f.write(&format!("@ref {}", func_name))?;
+            let handle = lib.find_struct(struct_name).unwrap();
+            f.write(&format!(
+                "@ref {}.{}",
+                handle.definition().to_type(),
+                element_name.to_snake_case()
+            ))?;
         }
         DocReference::Enum(enum_name) => {
             let enum_name = lib.find_enum(enum_name).unwrap();
@@ -93,6 +94,30 @@ fn reference_print(
                 "@ref {}_{}",
                 handle.name.to_camel_case(),
                 variant_name.to_camel_case()
+            ))?;
+        }
+        DocReference::Interface(interface_name) => {
+            let handle = lib.find_interface(interface_name).unwrap();
+            f.write(&format!("@ref {}", handle.to_type()))?;
+        }
+        DocReference::InterfaceMethod(interface_name, callback_name) => {
+            let handle = &lib.find_interface(interface_name).unwrap();
+            f.write(&format!(
+                "@ref {}.{}",
+                handle.to_type(),
+                callback_name.to_snake_case()
+            ))?;
+        }
+        DocReference::OneTimeCallback(interface_name) => {
+            let handle = lib.find_one_time_callback(interface_name).unwrap();
+            f.write(&format!("@ref {}", handle.to_type()))?;
+        }
+        DocReference::OneTimeCallbackMethod(interface_name, callback_name) => {
+            let handle = &lib.find_one_time_callback(interface_name).unwrap();
+            f.write(&format!(
+                "@ref {}.{}",
+                handle.to_type(),
+                callback_name.to_snake_case()
             ))?;
         }
     }

--- a/generators/c-oo-bindgen/src/doc.rs
+++ b/generators/c-oo-bindgen/src/doc.rs
@@ -1,0 +1,101 @@
+use crate::CFormatting;
+use heck::{CamelCase, SnakeCase};
+use oo_bindgen::doc::*;
+use oo_bindgen::formatting::*;
+use oo_bindgen::Library;
+
+pub(crate) fn doxygen_print(f: &mut dyn Printer, doc: &Doc, lib: &Library) -> FormattingResult<()> {
+    f.writeln("@brief ")?;
+    docstring_print(f, &doc.brief, lib)?;
+
+    for detail in &doc.details {
+        f.newline()?;
+
+        match detail {
+            DocParagraph::Details(docstring) => {
+                f.newline()?;
+                docstring_print(f, docstring, lib)?;
+            }
+            DocParagraph::Warning(docstring) => {
+                f.writeln("@warning ")?;
+                docstring_print(f, docstring, lib)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn docstring_print(
+    f: &mut dyn Printer,
+    docstring: &DocString,
+    lib: &Library,
+) -> FormattingResult<()> {
+    for el in docstring.elements() {
+        match el {
+            DocStringElement::Text(text) => f.write(text)?,
+            DocStringElement::Reference(reference) => reference_print(f, reference, lib)?,
+        }
+    }
+
+    Ok(())
+}
+
+fn reference_print(
+    f: &mut dyn Printer,
+    reference: &DocReference,
+    lib: &Library,
+) -> FormattingResult<()> {
+    match reference {
+        DocReference::Param(param_name) => f.write(&param_name.to_snake_case())?,
+        DocReference::Class(class_name) => {
+            let class_name = lib.find_class(class_name).unwrap().declaration();
+            f.write(&format!("@ref {}", class_name.to_type()))?;
+        }
+        DocReference::ClassMethod(class_name, method_name) => {
+            let func_name = &lib
+                .find_class(class_name)
+                .unwrap()
+                .find_method(method_name)
+                .unwrap()
+                .name;
+            f.write(&format!("@ref {}", func_name))?;
+        }
+        DocReference::Struct(struct_name) => {
+            let struct_name = lib.find_struct(struct_name).unwrap().declaration();
+            f.write(&format!("@ref {}", struct_name.to_type()))?;
+        }
+        DocReference::StructMethod(struct_name, method_name) => {
+            let func_name = &lib
+                .find_struct(struct_name)
+                .unwrap()
+                .find_method(method_name)
+                .unwrap()
+                .name;
+            f.write(&format!("@ref {}", func_name))?;
+        }
+        DocReference::StructElement(struct_name, element_name) => {
+            let func_name = &lib
+                .find_struct(struct_name)
+                .unwrap()
+                .find_element(element_name)
+                .unwrap()
+                .name;
+            f.write(&format!("@ref {}", func_name))?;
+        }
+        DocReference::Enum(enum_name) => {
+            let enum_name = lib.find_enum(enum_name).unwrap();
+            f.write(&format!("@ref {}", enum_name.to_type()))?;
+        }
+        DocReference::EnumVariant(enum_name, variant_name) => {
+            let handle = lib.find_enum(enum_name).unwrap();
+            f.write(&format!(
+                "@ref {}_{}",
+                handle.name.to_camel_case(),
+                variant_name.to_camel_case()
+            ))?;
+        }
+    }
+
+    Ok(())
+}

--- a/generators/dotnet-oo-bindgen/src/doc.rs
+++ b/generators/dotnet-oo-bindgen/src/doc.rs
@@ -1,3 +1,4 @@
+use crate::conversion::*;
 use heck::{CamelCase, MixedCase};
 use oo_bindgen::doc::*;
 use oo_bindgen::formatting::*;
@@ -38,6 +39,8 @@ pub(crate) fn docstring_print(
     for el in docstring.elements() {
         match el {
             DocStringElement::Text(text) => f.write(text)?,
+            DocStringElement::Null => f.write("<c>null</c>")?,
+            DocStringElement::Iterator => f.write("collection")?,
             DocStringElement::Reference(reference) => reference_print(f, reference, lib)?,
         }
     }
@@ -48,7 +51,7 @@ pub(crate) fn docstring_print(
 fn reference_print(
     f: &mut dyn Printer,
     reference: &DocReference,
-    _lib: &Library,
+    lib: &Library,
 ) -> FormattingResult<()> {
     match reference {
         DocReference::Param(param_name) => {
@@ -62,6 +65,30 @@ fn reference_print(
                 "<see cref=\"{}.{}\" />",
                 class_name.to_camel_case(),
                 method_name.to_camel_case()
+            ))?;
+        }
+        DocReference::ClassConstructor(class_name) => {
+            let func = lib
+                .find_class(class_name)
+                .unwrap()
+                .constructor
+                .as_ref()
+                .unwrap();
+            let params = func
+                .parameters
+                .iter()
+                .map(|param| param.param_type.as_dotnet_type())
+                .collect::<Vec<_>>()
+                .join(", ");
+            f.write(&format!(
+                "<see cref=\"{}.{}({})\" />",
+                class_name, class_name, params
+            ))?;
+        }
+        DocReference::ClassDestructor(class_name) => {
+            f.write(&format!(
+                "<see cref=\"{}.Dispose\" />",
+                class_name.to_camel_case()
             ))?;
         }
         DocReference::Struct(struct_name) => {

--- a/generators/dotnet-oo-bindgen/src/doc.rs
+++ b/generators/dotnet-oo-bindgen/src/doc.rs
@@ -1,27 +1,30 @@
-use heck::{CamelCase, MixedCase, ShoutySnakeCase};
+use heck::{CamelCase, MixedCase};
 use oo_bindgen::doc::*;
 use oo_bindgen::formatting::*;
 use oo_bindgen::Library;
 
-pub(crate) fn javadoc_print(f: &mut dyn Printer, doc: &Doc, lib: &Library) -> FormattingResult<()> {
-    f.newline()?;
+pub(crate) fn xmldoc_print(f: &mut dyn Printer, doc: &Doc, lib: &Library) -> FormattingResult<()> {
+    f.writeln("<summary>")?;
     docstring_print(f, &doc.brief, lib)?;
+    f.write("</summary>")?;
 
-    for detail in &doc.details {
-        f.newline()?;
-
-        match detail {
-            DocParagraph::Details(docstring) => {
-                f.writeln("<p>")?;
-                docstring_print(f, docstring, lib)?;
-                f.write("</p>")?;
-            }
-            DocParagraph::Warning(docstring) => {
-                f.writeln("<p><b>Warning:</b> ")?;
-                docstring_print(f, docstring, lib)?;
-                f.write("</p>")?;
+    if !doc.details.is_empty() {
+        f.writeln("<remarks>")?;
+        for detail in &doc.details {
+            match detail {
+                DocParagraph::Details(docstring) => {
+                    f.writeln("<para>")?;
+                    docstring_print(f, docstring, lib)?;
+                    f.write("</para>")?;
+                }
+                DocParagraph::Warning(docstring) => {
+                    f.writeln("<para><b>Warning:</b> ")?;
+                    docstring_print(f, docstring, lib)?;
+                    f.write("</para>")?;
+                }
             }
         }
+        f.writeln("</remarks>")?;
     }
 
     Ok(())
@@ -49,63 +52,69 @@ fn reference_print(
 ) -> FormattingResult<()> {
     match reference {
         DocReference::Param(param_name) => {
-            f.write(&format!("{{@code {}}}", param_name.to_mixed_case()))?
+            f.write(&format!("<c>{}</c>", param_name.to_mixed_case()))?
         }
         DocReference::Class(class_name) => {
-            f.write(&format!("{{@link {}}}", class_name.to_camel_case()))?;
+            f.write(&format!("<see cref=\"{}\" />", class_name.to_camel_case()))?;
         }
         DocReference::ClassMethod(class_name, method_name) => {
             f.write(&format!(
-                "{{@link {}#{}}}",
+                "<see cref=\"{}.{}\" />",
                 class_name.to_camel_case(),
-                method_name.to_mixed_case()
+                method_name.to_camel_case()
             ))?;
         }
         DocReference::Struct(struct_name) => {
-            f.write(&format!("{{@link {}}}", struct_name.to_camel_case()))?;
+            f.write(&format!("<see cref=\"{}\" />", struct_name.to_camel_case()))?;
         }
         DocReference::StructMethod(struct_name, method_name) => {
             f.write(&format!(
-                "{{@link {}#{}}}",
+                "<see cref=\"{}.{}\" />",
                 struct_name.to_camel_case(),
-                method_name.to_mixed_case()
+                method_name.to_camel_case()
             ))?;
         }
         DocReference::StructElement(struct_name, element_name) => {
             f.write(&format!(
-                "{{@link {}#{}}}",
+                "<see cref=\"{}.{}\" />",
                 struct_name.to_camel_case(),
-                element_name.to_mixed_case()
+                element_name.to_camel_case()
             ))?;
         }
         DocReference::Enum(enum_name) => {
-            f.write(&format!("{{@link {}}}", enum_name.to_camel_case()))?;
+            f.write(&format!("<see cref=\"{}\" />", enum_name.to_camel_case()))?;
         }
         DocReference::EnumVariant(enum_name, variant_name) => {
             f.write(&format!(
-                "{{@link {}#{}}}",
+                "<see cref=\"{}.{}\" />",
                 enum_name.to_camel_case(),
-                variant_name.to_shouty_snake_case()
+                variant_name.to_camel_case()
             ))?;
         }
         DocReference::Interface(interface_name) => {
-            f.write(&format!("{{@link {}}}", interface_name.to_camel_case()))?;
+            f.write(&format!(
+                "<see cref=\"I{}\" />",
+                interface_name.to_camel_case()
+            ))?;
         }
         DocReference::InterfaceMethod(interface_name, callback_name) => {
             f.write(&format!(
-                "{{@link {}#{}}}",
+                "<see cref=\"I{}.{}\" />",
                 interface_name.to_camel_case(),
-                callback_name.to_mixed_case()
+                callback_name.to_camel_case()
             ))?;
         }
         DocReference::OneTimeCallback(interface_name) => {
-            f.write(&format!("{{@link {}}}", interface_name.to_camel_case()))?;
+            f.write(&format!(
+                "<see cref=\"I{}\" />",
+                interface_name.to_camel_case()
+            ))?;
         }
         DocReference::OneTimeCallbackMethod(interface_name, callback_name) => {
             f.write(&format!(
-                "{{@link {}#{}}}",
+                "<see cref=\"I{}.{}\" />",
                 interface_name.to_camel_case(),
-                callback_name.to_mixed_case()
+                callback_name.to_camel_case()
             ))?;
         }
     }

--- a/generators/java-oo-bindgen/src/callback.rs
+++ b/generators/java-oo-bindgen/src/callback.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use crate::doc::*;
+use crate::*;
 use heck::{CamelCase, MixedCase};
 use oo_bindgen::callback::*;
 use oo_bindgen::native_function::*;

--- a/generators/java-oo-bindgen/src/callback.rs
+++ b/generators/java-oo-bindgen/src/callback.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use crate::doc::*;
 use heck::{CamelCase, MixedCase};
 use oo_bindgen::callback::*;
 use oo_bindgen::native_function::*;
@@ -17,21 +18,21 @@ pub(crate) fn generate(
             // Documentation
             documentation(f, |f| {
                 // Print top-level documentation
+                javadoc_print(f, &func.doc, lib)?;
                 f.newline()?;
-                doc_print(f, &func.doc, lib)?;
 
                 // Print each parameter value
                 for param in &func.parameters {
                     if let CallbackParameter::Parameter(param) = param {
                         f.writeln(&format!("@param {} ", param.name))?;
-                        doc_print(f, &param.doc, lib)?;
+                        docstring_print(f, &param.doc, lib)?;
                     }
                 }
 
                 // Print return value
                 if let ReturnType::Type(_, doc) = &func.return_type {
                     f.writeln("@return ")?;
-                    doc_print(f, doc, lib)?;
+                    docstring_print(f, doc, lib)?;
                 }
 
                 Ok(())
@@ -40,7 +41,7 @@ pub(crate) fn generate(
             // Callback signature
             f.writeln(&format!(
                 "{} {}(",
-                JavaReturnType(&func.return_type).as_java_type(),
+                func.return_type.as_java_type(),
                 func.name.to_mixed_case()
             ))?;
             f.write(
@@ -50,7 +51,7 @@ pub(crate) fn generate(
                     .filter_map(|param| match param {
                         CallbackParameter::Parameter(param) => Some(format!(
                             "{} {}",
-                            JavaType(&param.param_type).as_java_type(),
+                            param.param_type.as_java_type(),
                             param.name.to_mixed_case()
                         )),
                         _ => None,
@@ -103,7 +104,7 @@ pub(crate) fn generate(
                         indented(f, |f| {
                             f.writeln(&format!(
                                 "public {} callback(",
-                                JavaReturnType(&func.return_type).as_native_type()
+                                func.return_type.as_native_type()
                             ))?;
                             f.write(
                                 &func
@@ -112,7 +113,7 @@ pub(crate) fn generate(
                                     .map(|param| match param {
                                         CallbackParameter::Parameter(param) => format!(
                                             "{} {}",
-                                            JavaType(&param.param_type).as_native_type(),
+                                            param.param_type.as_native_type(),
                                             param.name.to_mixed_case()
                                         ),
                                         CallbackParameter::Arg(name) => {

--- a/generators/java-oo-bindgen/src/class.rs
+++ b/generators/java-oo-bindgen/src/class.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use crate::doc::*;
+use crate::*;
 use heck::{CamelCase, MixedCase};
 use oo_bindgen::class::*;
 use oo_bindgen::native_function::*;
@@ -12,9 +12,7 @@ pub(crate) fn generate(
     let classname = class.name().to_camel_case();
 
     // Documentation
-    documentation(f, |f| {
-        javadoc_print(f, &class.doc, lib)
-    })?;
+    documentation(f, |f| javadoc_print(f, &class.doc, lib))?;
 
     // Class definition
     f.writeln(&format!("public class {}", classname))?;

--- a/generators/java-oo-bindgen/src/class.rs
+++ b/generators/java-oo-bindgen/src/class.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use crate::doc::*;
 use heck::{CamelCase, MixedCase};
 use oo_bindgen::class::*;
 use oo_bindgen::native_function::*;
@@ -11,13 +12,9 @@ pub(crate) fn generate(
     let classname = class.name().to_camel_case();
 
     // Documentation
-    if !class.doc.is_empty() {
-        documentation(f, |f| {
-            f.newline()?;
-            doc_print(f, &class.doc, lib)?;
-            Ok(())
-        })?;
-    }
+    documentation(f, |f| {
+        javadoc_print(f, &class.doc, lib)
+    })?;
 
     // Class definition
     f.writeln(&format!("public class {}", classname))?;
@@ -75,13 +72,13 @@ fn generate_constructor(
 ) -> FormattingResult<()> {
     documentation(f, |f| {
         // Print top-level documentation
+        javadoc_print(f, &constructor.doc, lib)?;
         f.newline()?;
-        doc_print(f, &constructor.doc, lib)?;
 
         // Print each parameter value
         for param in constructor.parameters.iter() {
             f.writeln(&format!("@param {} ", param.name))?;
-            doc_print(f, &param.doc, lib)?;
+            docstring_print(f, &param.doc, lib)?;
         }
 
         Ok(())
@@ -95,7 +92,7 @@ fn generate_constructor(
             .map(|param| {
                 format!(
                     "{} {}",
-                    JavaType(&param.param_type).as_java_type(),
+                    param.param_type.as_java_type(),
                     param.name.to_mixed_case()
                 )
             })
@@ -116,13 +113,13 @@ fn generate_destructor(
 ) -> FormattingResult<()> {
     documentation(f, |f| {
         // Print top-level documentation
+        javadoc_print(f, &destructor.doc, lib)?;
         f.newline()?;
-        doc_print(f, &destructor.doc, lib)?;
 
         // Print each parameter value
         for param in destructor.parameters.iter().skip(1) {
             f.writeln(&format!("@param {} ", param.name))?;
-            doc_print(f, &param.doc, lib)?;
+            docstring_print(f, &param.doc, lib)?;
         }
 
         Ok(())
@@ -147,26 +144,26 @@ fn generate_destructor(
 fn generate_method(f: &mut dyn Printer, method: &Method, lib: &Library) -> FormattingResult<()> {
     documentation(f, |f| {
         // Print top-level documentation
+        javadoc_print(f, &method.native_function.doc, lib)?;
         f.newline()?;
-        doc_print(f, &method.native_function.doc, lib)?;
 
         // Print each parameter value
         for param in method.native_function.parameters.iter().skip(1) {
             f.writeln(&format!("@param {} ", param.name))?;
-            doc_print(f, &param.doc, lib)?;
+            docstring_print(f, &param.doc, lib)?;
         }
 
         // Print return value
         if let ReturnType::Type(_, doc) = &method.native_function.return_type {
             f.writeln("@return ")?;
-            doc_print(f, doc, lib)?;
+            docstring_print(f, doc, lib)?;
         }
         Ok(())
     })?;
 
     f.writeln(&format!(
         "public {} {}(",
-        JavaReturnType(&method.native_function.return_type).as_java_type(),
+        method.native_function.return_type.as_java_type(),
         method.name.to_mixed_case()
     ))?;
     f.write(
@@ -178,7 +175,7 @@ fn generate_method(f: &mut dyn Printer, method: &Method, lib: &Library) -> Forma
             .map(|param| {
                 format!(
                     "{} {}",
-                    JavaType(&param.param_type).as_java_type(),
+                    param.param_type.as_java_type(),
                     param.name.to_mixed_case()
                 )
             })
@@ -205,26 +202,26 @@ fn generate_static_method(
 ) -> FormattingResult<()> {
     documentation(f, |f| {
         // Print top-level documentation
+        javadoc_print(f, &method.native_function.doc, lib)?;
         f.newline()?;
-        doc_print(f, &method.native_function.doc, lib)?;
 
         // Print each parameter value
         for param in method.native_function.parameters.iter() {
             f.writeln(&format!("@param {} ", param.name))?;
-            doc_print(f, &param.doc, lib)?;
+            docstring_print(f, &param.doc, lib)?;
         }
 
         // Print return value
         if let ReturnType::Type(_, doc) = &method.native_function.return_type {
             f.writeln("@return ")?;
-            doc_print(f, doc, lib)?;
+            docstring_print(f, doc, lib)?;
         }
         Ok(())
     })?;
 
     f.writeln(&format!(
         "public static {} {}(",
-        JavaReturnType(&method.native_function.return_type).as_java_type(),
+        method.native_function.return_type.as_java_type(),
         method.name.to_mixed_case()
     ))?;
     f.write(
@@ -235,7 +232,7 @@ fn generate_static_method(
             .map(|param| {
                 format!(
                     "{} {}",
-                    JavaType(&param.param_type).as_java_type(),
+                    param.param_type.as_java_type(),
                     param.name.to_mixed_case()
                 )
             })
@@ -254,7 +251,7 @@ fn generate_async_method(
     method: &AsyncMethod,
     lib: &Library,
 ) -> FormattingResult<()> {
-    let return_type = JavaType(&method.return_type).as_java_type();
+    let return_type = method.return_type.as_java_type();
     let one_time_callback_name = method.one_time_callback_name.to_camel_case();
     let one_time_callback_param_name = method.one_time_callback_param_name.to_mixed_case();
     let callback_param_name = method.callback_param_name.to_mixed_case();
@@ -262,29 +259,27 @@ fn generate_async_method(
     let future_type = format!("java.util.concurrent.CompletableFuture<{}>", return_type);
 
     // Documentation
-    if !method.native_function.doc.is_empty() {
-        documentation(f, |f| {
-            // Print top-level documentation
-            f.newline()?;
-            doc_print(f, &method.native_function.doc, lib)?;
+    documentation(f, |f| {
+        // Print top-level documentation
+        javadoc_print(f, &method.native_function.doc, lib)?;
+        f.newline()?;
 
-            // Print each parameter value
-            for param in method
-                .native_function
-                .parameters
-                .iter()
-                .skip(1)
-                .filter(|param| !matches!(param.param_type, Type::OneTimeCallback(_)))
-            {
-                f.writeln(&format!("@param {} ", param.name))?;
-                doc_print(f, &param.doc, lib)?;
-            }
+        // Print each parameter value
+        for param in method
+            .native_function
+            .parameters
+            .iter()
+            .skip(1)
+            .filter(|param| !matches!(param.param_type, Type::OneTimeCallback(_)))
+        {
+            f.writeln(&format!("@param {} ", param.name))?;
+            docstring_print(f, &param.doc, lib)?;
+        }
 
-            // Print return value
-            f.writeln("@return ")?;
-            doc_print(f, &method.return_type_doc, lib)
-        })?;
-    }
+        // Print return value
+        f.writeln("@return ")?;
+        docstring_print(f, &method.return_type_doc, lib)
+    })?;
 
     f.writeln(&format!(
         "public java.util.concurrent.CompletionStage<{}> {}(",
@@ -301,7 +296,7 @@ fn generate_async_method(
             .map(|param| {
                 format!(
                     "{} {}",
-                    JavaType(&param.param_type).as_java_type(),
+                    param.param_type.as_java_type(),
                     param.name.to_mixed_case()
                 )
             })

--- a/generators/java-oo-bindgen/src/conversion.rs
+++ b/generators/java-oo-bindgen/src/conversion.rs
@@ -43,10 +43,9 @@ impl JavaType for Type {
                 "java.util.Collection<{}>",
                 handle.item_type.name().to_camel_case()
             ),
-            Type::Collection(handle) => format!(
-                "java.util.Collection<{}>",
-                handle.item_type.as_java_type()
-            ),
+            Type::Collection(handle) => {
+                format!("java.util.Collection<{}>", handle.item_type.as_java_type())
+            }
             Type::Duration(_) => "java.time.Duration".to_string(),
         }
     }

--- a/generators/java-oo-bindgen/src/conversion.rs
+++ b/generators/java-oo-bindgen/src/conversion.rs
@@ -10,12 +10,17 @@ use oo_bindgen::native_enum::*;
 use oo_bindgen::native_function::*;
 use oo_bindgen::native_struct::*;
 
-pub(crate) struct JavaType<'a>(pub(crate) &'a Type);
+pub(crate) trait JavaType {
+    fn as_java_type(&self) -> String;
+    fn as_native_type(&self) -> String;
+    fn conversion(&self) -> Option<Box<dyn TypeConverter>>;
+    fn as_java_arg(&self, param_name: &str) -> String;
+}
 
-impl<'a> JavaType<'a> {
+impl JavaType for Type {
     /// Returns the Java natural type
-    pub(crate) fn as_java_type(&self) -> String {
-        match self.0 {
+    fn as_java_type(&self) -> String {
+        match self {
             Type::Bool => "Boolean".to_string(),
             Type::Uint8 => "UByte".to_string(),
             Type::Sint8 => "Byte".to_string(),
@@ -40,15 +45,15 @@ impl<'a> JavaType<'a> {
             ),
             Type::Collection(handle) => format!(
                 "java.util.Collection<{}>",
-                JavaType(&handle.item_type).as_java_type()
+                handle.item_type.as_java_type()
             ),
             Type::Duration(_) => "java.time.Duration".to_string(),
         }
     }
 
     /// Return the Java representation of the native C type
-    pub(crate) fn as_native_type(&self) -> String {
-        match self.0 {
+    fn as_native_type(&self) -> String {
+        match self {
             Type::Bool => "byte".to_string(),
             Type::Uint8 => "byte".to_string(),
             Type::Sint8 => "byte".to_string(),
@@ -82,8 +87,8 @@ impl<'a> JavaType<'a> {
         }
     }
 
-    pub(crate) fn conversion(&self) -> Option<Box<dyn TypeConverter>> {
-        match self.0 {
+    fn conversion(&self) -> Option<Box<dyn TypeConverter>> {
+        match self {
             Type::Bool => Some(Box::new(BoolConverter)),
             Type::Uint8 => Some(Box::new(UByteConverter)),
             Type::Sint8 => None,
@@ -114,8 +119,8 @@ impl<'a> JavaType<'a> {
         }
     }
 
-    pub(crate) fn as_java_arg(&self, param_name: &str) -> String {
-        match self.0 {
+    fn as_java_arg(&self, param_name: &str) -> String {
+        match self {
             Type::Bool => format!("_{}", param_name.to_mixed_case()),
             Type::Uint8 => format!("_{}", param_name.to_mixed_case()),
             Type::Sint8 => param_name.to_mixed_case(),
@@ -141,6 +146,36 @@ impl<'a> JavaType<'a> {
                 DurationMapping::Seconds => format!("_{}", param_name.to_mixed_case()),
                 DurationMapping::SecondsFloat => format!("_{}", param_name.to_mixed_case()),
             },
+        }
+    }
+}
+
+impl JavaType for ReturnType {
+    fn as_java_type(&self) -> String {
+        match self {
+            ReturnType::Void => "void".to_string(),
+            ReturnType::Type(return_type, _) => return_type.as_java_type(),
+        }
+    }
+
+    fn as_native_type(&self) -> String {
+        match self {
+            ReturnType::Void => "void".to_string(),
+            ReturnType::Type(return_type, _) => return_type.as_native_type(),
+        }
+    }
+
+    fn conversion(&self) -> Option<Box<dyn TypeConverter>> {
+        match self {
+            ReturnType::Void => None,
+            ReturnType::Type(return_type, _) => return_type.conversion(),
+        }
+    }
+
+    fn as_java_arg(&self, param_name: &str) -> String {
+        match self {
+            ReturnType::Void => "void".to_string(),
+            ReturnType::Type(return_type, _) => return_type.as_java_arg(param_name),
         }
     }
 }
@@ -452,7 +487,6 @@ struct CollectionConverter(CollectionHandle);
 impl TypeConverter for CollectionConverter {
     fn convert_to_native(&self, f: &mut dyn Printer, from: &str, to: &str) -> FormattingResult<()> {
         let builder_name = format!("_{}Builder", from.replace(".", "_"));
-        let java_type = JavaType(&self.0.item_type);
 
         if self.0.has_reserve {
             f.writeln(&format!(
@@ -468,16 +502,16 @@ impl TypeConverter for CollectionConverter {
 
         f.writeln(&format!(
             "for ({} __value : {})",
-            java_type.as_java_type(),
+            self.0.item_type.as_java_type(),
             from
         ))?;
         blocked(f, |f| {
-            let converter = java_type.conversion();
+            let converter = self.0.item_type.conversion();
             let value_name = if let Some(converter) = &converter {
                 converter.convert_to_native(
                     f,
                     "__value",
-                    &format!("{} ___value = ", java_type.as_native_type()),
+                    &format!("{} ___value = ", self.0.item_type.as_native_type()),
                 )?;
                 "___value"
             } else {
@@ -514,7 +548,7 @@ impl TypeConverter for CollectionConverter {
         f.writeln(&format!(
             "{}java.util.Collections.unmodifiableList(new java.util.List<{}>());",
             to,
-            JavaType(&self.0.item_type).as_java_type()
+            self.0.item_type.as_java_type()
         ))
     }
 }
@@ -570,24 +604,6 @@ impl TypeConverter for DurationSecondsFloatConverter {
     }
 }
 
-pub(crate) struct JavaReturnType<'a>(pub(crate) &'a ReturnType);
-
-impl<'a> JavaReturnType<'a> {
-    pub(crate) fn as_java_type(&self) -> String {
-        match self.0 {
-            ReturnType::Void => "void".to_string(),
-            ReturnType::Type(return_type, _) => JavaType(return_type).as_java_type(),
-        }
-    }
-
-    pub(crate) fn as_native_type(&self) -> String {
-        match self.0 {
-            ReturnType::Void => "void".to_string(),
-            ReturnType::Type(return_type, _) => JavaType(return_type).as_native_type(),
-        }
-    }
-}
-
 pub(crate) fn call_native_function(
     f: &mut dyn Printer,
     method: &NativeFunction,
@@ -597,7 +613,7 @@ pub(crate) fn call_native_function(
 ) -> FormattingResult<()> {
     // Write the type conversions
     for (idx, param) in method.parameters.iter().enumerate() {
-        if let Some(converter) = JavaType(&param.param_type).conversion() {
+        if let Some(converter) = param.param_type.conversion() {
             let mut param_name = param.name.to_mixed_case();
             if idx == 0 {
                 if let Some(first_param) = first_param_is_self.clone() {
@@ -609,7 +625,7 @@ pub(crate) fn call_native_function(
                 &param_name,
                 &format!(
                     "{} _{} = ",
-                    JavaType(&param.param_type).as_native_type(),
+                    param.param_type.as_native_type(),
                     param.name.to_mixed_case()
                 ),
             )?;
@@ -621,7 +637,7 @@ pub(crate) fn call_native_function(
     if let ReturnType::Type(return_type, _) = &method.return_type {
         f.write(&format!(
             "{} _result = {}.{}(",
-            JavaType(return_type).as_native_type(),
+            return_type.as_native_type(),
             NATIVE_FUNCTIONS_CLASSNAME,
             method.name
         ))?;
@@ -633,7 +649,7 @@ pub(crate) fn call_native_function(
         &method
             .parameters
             .iter()
-            .map(|param| JavaType(&param.param_type).as_java_arg(&param.name.to_mixed_case()))
+            .map(|param| param.param_type.as_java_arg(&param.name.to_mixed_case()))
             .collect::<Vec<String>>()
             .join(", "),
     )?;
@@ -641,14 +657,14 @@ pub(crate) fn call_native_function(
 
     //Cleanup type conversions
     for param in method.parameters.iter() {
-        if let Some(converter) = JavaType(&param.param_type).conversion() {
+        if let Some(converter) = param.param_type.conversion() {
             converter.convert_to_native_cleanup(f, &format!("_{}", param.name.to_mixed_case()))?;
         }
     }
 
     // Convert the result (if required) and return
     if let ReturnType::Type(return_type, _) = &method.return_type {
-        if let Some(converter) = JavaType(&return_type).conversion() {
+        if let Some(converter) = return_type.conversion() {
             if !is_constructor {
                 return converter.convert_from_native(f, "_result", return_destination);
             }
@@ -667,13 +683,13 @@ pub(crate) fn call_java_function(
 ) -> FormattingResult<()> {
     // Write the type conversions
     for param in method.params() {
-        if let Some(converter) = JavaType(&param.param_type).conversion() {
+        if let Some(converter) = param.param_type.conversion() {
             converter.convert_from_native(
                 f,
                 &param.name,
                 &format!(
                     "{} _{} = ",
-                    JavaType(&param.param_type).as_java_type(),
+                    param.param_type.as_java_type(),
                     param.name.to_mixed_case()
                 ),
             )?;
@@ -684,10 +700,10 @@ pub(crate) fn call_java_function(
     f.newline()?;
     let method_name = method.name.to_mixed_case();
     if let ReturnType::Type(return_type, _) = &method.return_type {
-        if JavaType(&return_type).conversion().is_some() {
+        if return_type.conversion().is_some() {
             f.write(&format!(
                 "{} _result = _arg._impl.{}(",
-                JavaType(&return_type).as_java_type(),
+                return_type.as_java_type(),
                 method_name
             ))?;
         } else {
@@ -703,7 +719,7 @@ pub(crate) fn call_java_function(
     f.write(
         &method
             .params()
-            .map(|param| JavaType(&param.param_type).as_java_arg(&param.name))
+            .map(|param| param.param_type.as_java_arg(&param.name))
             .collect::<Vec<String>>()
             .join(", "),
     )?;
@@ -711,7 +727,7 @@ pub(crate) fn call_java_function(
 
     // Convert the result (if required)
     if let ReturnType::Type(return_type, _) = &method.return_type {
-        if let Some(converter) = JavaType(&return_type).conversion() {
+        if let Some(converter) = return_type.conversion() {
             converter.convert_to_native(f, "_result", return_destination)?;
         }
     }

--- a/generators/java-oo-bindgen/src/doc.rs
+++ b/generators/java-oo-bindgen/src/doc.rs
@@ -1,0 +1,106 @@
+use heck::{CamelCase, MixedCase, ShoutySnakeCase};
+use oo_bindgen::doc::*;
+use oo_bindgen::formatting::*;
+use oo_bindgen::Library;
+
+pub(crate) fn javadoc_print(f: &mut dyn Printer, doc: &Doc, lib: &Library) -> FormattingResult<()> {
+    f.newline()?;
+    docstring_print(f, &doc.brief, lib)?;
+
+    for detail in &doc.details {
+        f.newline()?;
+
+        match detail {
+            DocParagraph::Details(docstring) => {
+                f.writeln("<p>")?;
+                docstring_print(f, docstring, lib)?;
+                f.write("</p>")?;
+            }
+            DocParagraph::Warning(docstring) => {
+                f.writeln("<p><b>Warning:</b> ")?;
+                docstring_print(f, docstring, lib)?;
+                f.write("</p>")?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn docstring_print(
+    f: &mut dyn Printer,
+    docstring: &DocString,
+    lib: &Library,
+) -> FormattingResult<()> {
+    for el in docstring.elements() {
+        match el {
+            DocStringElement::Text(text) => f.write(text)?,
+            DocStringElement::Reference(reference) => reference_print(f, reference, lib)?,
+        }
+    }
+
+    Ok(())
+}
+
+fn reference_print(
+    f: &mut dyn Printer,
+    reference: &DocReference,
+    _lib: &Library,
+) -> FormattingResult<()> {
+    match reference {
+        DocReference::Param(param_name) => {
+            f.write(&format!("{{@code {}}}", param_name.to_mixed_case()))?
+        }
+        DocReference::Class(class_name) => {
+            f.write(&format!("{{@link {}}}", class_name.to_camel_case()))?;
+        }
+        DocReference::ClassMethod(class_name, method_name) => {
+            f.write(&format!("{{@link {}#{}}}", class_name.to_camel_case(), method_name.to_mixed_case()))?;
+        }
+        DocReference::Struct(struct_name) => {
+            f.write(&format!("{{@link {}}}", struct_name.to_camel_case()))?;
+        }
+        DocReference::StructMethod(struct_name, method_name) => {
+            f.write(&format!("{{@link {}#{}}}", struct_name.to_camel_case(), method_name.to_mixed_case()))?;
+        }
+        DocReference::StructElement(struct_name, element_name) => {
+            f.write(&format!(
+                "{{@link {}#{}}}",
+                struct_name.to_camel_case(),
+                element_name.to_mixed_case()
+            ))?;
+        }
+        DocReference::Enum(enum_name) => {
+            f.write(&format!("{{@link {}}}", enum_name.to_camel_case()))?;
+        }
+        DocReference::EnumVariant(enum_name, variant_name) => {
+            f.write(&format!(
+                "{{@link {}#{}}}",
+                enum_name.to_camel_case(),
+                variant_name.to_shouty_snake_case()
+            ))?;
+        }
+        DocReference::Interface(interface_name) => {
+            f.write(&format!("{{@link {}}}", interface_name.to_camel_case()))?;
+        }
+        DocReference::InterfaceMethod(interface_name, callback_name) => {
+            f.write(&format!(
+                "{{@link {}#{}}}",
+                interface_name.to_camel_case(),
+                callback_name.to_mixed_case()
+            ))?;
+        }
+        DocReference::OneTimeCallback(interface_name) => {
+            f.write(&format!("{{@link {}}}", interface_name.to_camel_case()))?;
+        }
+        DocReference::OneTimeCallbackMethod(interface_name, callback_name) => {
+            f.write(&format!(
+                "{{@link {}#{}}}",
+                interface_name.to_camel_case(),
+                callback_name.to_mixed_case()
+            ))?;
+        }
+    }
+
+    Ok(())
+}

--- a/generators/java-oo-bindgen/src/enumeration.rs
+++ b/generators/java-oo-bindgen/src/enumeration.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use crate::doc::*;
+use crate::*;
 use heck::{CamelCase, ShoutySnakeCase};
 use oo_bindgen::native_enum::*;
 
@@ -11,18 +11,14 @@ pub(crate) fn generate(
     let enum_name = native_enum.name.to_camel_case();
 
     // Documentation
-    documentation(f, |f| {
-        javadoc_print(f, &native_enum.doc, lib)
-    })?;
+    documentation(f, |f| javadoc_print(f, &native_enum.doc, lib))?;
 
     // Enum definition
     f.writeln(&format!("public enum {}", enum_name))?;
     blocked(f, |f| {
         // Write the variants
         for variant in &native_enum.variants {
-            documentation(f, |f| {
-                javadoc_print(f, &variant.doc, lib)
-            })?;
+            documentation(f, |f| javadoc_print(f, &variant.doc, lib))?;
             f.writeln(&format!("{},", variant.name.to_shouty_snake_case()))?;
         }
         f.write(";")?;

--- a/generators/java-oo-bindgen/src/enumeration.rs
+++ b/generators/java-oo-bindgen/src/enumeration.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use crate::doc::*;
 use heck::{CamelCase, ShoutySnakeCase};
 use oo_bindgen::native_enum::*;
 
@@ -10,13 +11,9 @@ pub(crate) fn generate(
     let enum_name = native_enum.name.to_camel_case();
 
     // Documentation
-    if !native_enum.doc.is_empty() {
-        documentation(f, |f| {
-            f.newline()?;
-            doc_print(f, &native_enum.doc, lib)?;
-            Ok(())
-        })?;
-    }
+    documentation(f, |f| {
+        javadoc_print(f, &native_enum.doc, lib)
+    })?;
 
     // Enum definition
     f.writeln(&format!("public enum {}", enum_name))?;
@@ -24,9 +21,7 @@ pub(crate) fn generate(
         // Write the variants
         for variant in &native_enum.variants {
             documentation(f, |f| {
-                f.newline()?;
-                doc_print(f, &variant.doc, lib)?;
-                Ok(())
+                javadoc_print(f, &variant.doc, lib)
             })?;
             f.writeln(&format!("{},", variant.name.to_shouty_snake_case()))?;
         }

--- a/generators/java-oo-bindgen/src/interface.rs
+++ b/generators/java-oo-bindgen/src/interface.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use crate::doc::*;
+use crate::*;
 use heck::{CamelCase, MixedCase};
 use oo_bindgen::callback::*;
 use oo_bindgen::native_function::*;

--- a/generators/java-oo-bindgen/src/interface.rs
+++ b/generators/java-oo-bindgen/src/interface.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use crate::doc::*;
 use heck::{CamelCase, MixedCase};
 use oo_bindgen::callback::*;
 use oo_bindgen::native_function::*;
@@ -12,8 +13,7 @@ pub(crate) fn generate(
 
     documentation(f, |f| {
         // Print top-level documentation
-        f.newline()?;
-        doc_print(f, &interface.doc, lib)
+        javadoc_print(f, &interface.doc, lib)
     })?;
 
     f.writeln(&format!("public interface {}", interface_name))?;
@@ -26,21 +26,21 @@ pub(crate) fn generate(
             // Documentation
             documentation(f, |f| {
                 // Print top-level documentation
+                javadoc_print(f, &func.doc, lib)?;
                 f.newline()?;
-                doc_print(f, &func.doc, lib)?;
 
                 // Print each parameter value
                 for param in &func.parameters {
                     if let CallbackParameter::Parameter(param) = param {
                         f.writeln(&format!("@param {} ", param.name))?;
-                        doc_print(f, &param.doc, lib)?;
+                        docstring_print(f, &param.doc, lib)?;
                     }
                 }
 
                 // Print return value
                 if let ReturnType::Type(_, doc) = &func.return_type {
                     f.writeln("@return ")?;
-                    doc_print(f, doc, lib)?;
+                    docstring_print(f, doc, lib)?;
                 }
 
                 Ok(())
@@ -49,7 +49,7 @@ pub(crate) fn generate(
             // Callback signature
             f.writeln(&format!(
                 "{} {}(",
-                JavaReturnType(&func.return_type).as_java_type(),
+                func.return_type.as_java_type(),
                 func.name.to_mixed_case()
             ))?;
             f.write(
@@ -59,7 +59,7 @@ pub(crate) fn generate(
                     .filter_map(|param| match param {
                         CallbackParameter::Parameter(param) => Some(format!(
                             "{} {}",
-                            JavaType(&param.param_type).as_java_type(),
+                            param.param_type.as_java_type(),
                             param.name.to_mixed_case()
                         )),
                         _ => None,
@@ -113,7 +113,7 @@ pub(crate) fn generate(
                         indented(f, |f| {
                             f.writeln(&format!(
                                 "public {} callback(",
-                                JavaReturnType(&func.return_type).as_native_type()
+                                func.return_type.as_native_type()
                             ))?;
                             f.write(
                                 &func
@@ -122,7 +122,7 @@ pub(crate) fn generate(
                                     .map(|param| match param {
                                         CallbackParameter::Parameter(param) => format!(
                                             "{} {}",
-                                            JavaType(&param.param_type).as_native_type(),
+                                            param.param_type.as_native_type(),
                                             param.name.to_mixed_case()
                                         ),
                                         CallbackParameter::Arg(name) => {

--- a/generators/java-oo-bindgen/src/lib.rs
+++ b/generators/java-oo-bindgen/src/lib.rs
@@ -47,7 +47,6 @@ clippy::all
 use crate::conversion::*;
 use crate::formatting::*;
 use heck::{CamelCase, KebabCase};
-use oo_bindgen::doc::*;
 use oo_bindgen::formatting::*;
 use oo_bindgen::platforms::*;
 use oo_bindgen::*;
@@ -57,6 +56,7 @@ use std::path::PathBuf;
 mod callback;
 mod class;
 mod conversion;
+mod doc;
 mod enumeration;
 mod formatting;
 mod interface;
@@ -69,21 +69,6 @@ pub struct JavaBindgenConfig {
     pub ffi_name: String,
     pub group_id: String,
     pub platforms: PlatformLocations,
-}
-
-pub(crate) fn doc_print(f: &mut dyn Printer, doc: &Doc, _lib: &Library) -> FormattingResult<()> {
-    for doc in doc {
-        match doc {
-            DocElement::Text(text) => f.write(text)?,
-            DocElement::Reference(typename) => {
-                f.write(&format!("{{@link {}}}", typename.to_camel_case()))?;
-            }
-            DocElement::Warning(text) => {
-                f.write(&format!("@warning {}", text))?;
-            }
-        }
-    }
-    Ok(())
 }
 
 impl JavaBindgenConfig {
@@ -210,7 +195,7 @@ fn generate_native_func_class(lib: &Library, config: &JavaBindgenConfig) -> Form
             f.newline()?;
             f.write(&format!(
                 "static native {} {}(",
-                JavaReturnType(&handle.return_type).as_native_type(),
+                handle.return_type.as_native_type(),
                 handle.name
             ))?;
 
@@ -221,7 +206,7 @@ fn generate_native_func_class(lib: &Library, config: &JavaBindgenConfig) -> Form
                     .map(|param| {
                         format!(
                             "{} {}",
-                            JavaType(&param.param_type).as_native_type(),
+                            param.param_type.as_native_type(),
                             param.name
                         )
                     })

--- a/generators/java-oo-bindgen/src/lib.rs
+++ b/generators/java-oo-bindgen/src/lib.rs
@@ -203,13 +203,7 @@ fn generate_native_func_class(lib: &Library, config: &JavaBindgenConfig) -> Form
                 &handle
                     .parameters
                     .iter()
-                    .map(|param| {
-                        format!(
-                            "{} {}",
-                            param.param_type.as_native_type(),
-                            param.name
-                        )
-                    })
+                    .map(|param| format!("{} {}", param.param_type.as_native_type(), param.name))
                     .collect::<Vec<String>>()
                     .join(", "),
             )?;

--- a/generators/java-oo-bindgen/src/structure.rs
+++ b/generators/java-oo-bindgen/src/structure.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use crate::doc::*;
+use crate::*;
 use heck::{CamelCase, MixedCase};
 use oo_bindgen::native_function::*;
 use oo_bindgen::native_struct::*;
@@ -12,18 +12,14 @@ pub(crate) fn generate(
     let struct_name = native_struct.name().to_camel_case();
 
     // Documentation
-    documentation(f, |f| {
-        javadoc_print(f, &native_struct.doc(), lib)
-    })?;
+    documentation(f, |f| javadoc_print(f, &native_struct.doc(), lib))?;
 
     // Structure definition
     f.writeln(&format!("public class {}", struct_name))?;
     blocked(f, |f| {
         // Write Java structure elements
         for el in native_struct.elements() {
-            documentation(f, |f| {
-                javadoc_print(f, &el.doc, lib)
-            })?;
+            documentation(f, |f| javadoc_print(f, &el.doc, lib))?;
 
             f.writeln(&format!(
                 "public {} {};",

--- a/generators/java-oo-bindgen/src/structure.rs
+++ b/generators/java-oo-bindgen/src/structure.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use crate::doc::*;
 use heck::{CamelCase, MixedCase};
 use oo_bindgen::native_function::*;
 use oo_bindgen::native_struct::*;
@@ -11,31 +12,22 @@ pub(crate) fn generate(
     let struct_name = native_struct.name().to_camel_case();
 
     // Documentation
-    if !native_struct.doc().is_empty() {
-        documentation(f, |f| {
-            f.newline()?;
-            doc_print(f, &native_struct.doc(), lib)?;
-            Ok(())
-        })?;
-    }
+    documentation(f, |f| {
+        javadoc_print(f, &native_struct.doc(), lib)
+    })?;
 
     // Structure definition
     f.writeln(&format!("public class {}", struct_name))?;
     blocked(f, |f| {
         // Write Java structure elements
         for el in native_struct.elements() {
-            if !el.doc.is_empty() {
-                documentation(f, |f| {
-                    f.newline()?;
-                    doc_print(f, &el.doc, lib)?;
-                    Ok(())
-                })?;
-            }
+            documentation(f, |f| {
+                javadoc_print(f, &el.doc, lib)
+            })?;
 
-            let java_type = JavaType(&el.element_type);
             f.writeln(&format!(
                 "public {} {};",
-                java_type.as_java_type(),
+                el.element_type.as_java_type(),
                 el.name.to_mixed_case()
             ))?;
         }
@@ -46,26 +38,26 @@ pub(crate) fn generate(
         for method in &native_struct.methods {
             documentation(f, |f| {
                 // Print top-level documentation
+                javadoc_print(f, &method.native_function.doc, lib)?;
                 f.newline()?;
-                doc_print(f, &method.native_function.doc, lib)?;
 
                 // Print each parameter value
                 for param in method.native_function.parameters.iter().skip(1) {
                     f.writeln(&format!("@param {} ", param.name))?;
-                    doc_print(f, &param.doc, lib)?;
+                    docstring_print(f, &param.doc, lib)?;
                 }
 
                 // Print return value
                 if let ReturnType::Type(_, doc) = &method.native_function.return_type {
                     f.writeln("@return ")?;
-                    doc_print(f, doc, lib)?;
+                    docstring_print(f, doc, lib)?;
                 }
                 Ok(())
             })?;
 
             f.writeln(&format!(
                 "public {} {}(",
-                JavaReturnType(&method.native_function.return_type).as_java_type(),
+                method.native_function.return_type.as_java_type(),
                 method.name.to_mixed_case()
             ))?;
             f.write(
@@ -77,7 +69,7 @@ pub(crate) fn generate(
                     .map(|param| {
                         format!(
                             "{} {}",
-                            JavaType(&param.param_type).as_java_type(),
+                            param.param_type.as_java_type(),
                             param.name.to_mixed_case()
                         )
                     })
@@ -103,26 +95,26 @@ pub(crate) fn generate(
         for method in &native_struct.static_methods {
             documentation(f, |f| {
                 // Print top-level documentation
+                javadoc_print(f, &method.native_function.doc, lib)?;
                 f.newline()?;
-                doc_print(f, &method.native_function.doc, lib)?;
 
                 // Print each parameter value
                 for param in method.native_function.parameters.iter() {
                     f.writeln(&format!("@param {} ", param.name))?;
-                    doc_print(f, &param.doc, lib)?;
+                    docstring_print(f, &param.doc, lib)?;
                 }
 
                 // Print return value
                 if let ReturnType::Type(_, doc) = &method.native_function.return_type {
                     f.writeln("@return ")?;
-                    doc_print(f, doc, lib)?;
+                    docstring_print(f, doc, lib)?;
                 }
                 Ok(())
             })?;
 
             f.writeln(&format!(
                 "public static {} {}(",
-                JavaReturnType(&method.native_function.return_type).as_java_type(),
+                method.native_function.return_type.as_java_type(),
                 method.name.to_mixed_case()
             ))?;
             f.write(
@@ -133,7 +125,7 @@ pub(crate) fn generate(
                     .map(|param| {
                         format!(
                             "{} {}",
-                            JavaType(&param.param_type).as_java_type(),
+                            param.param_type.as_java_type(),
                             param.name.to_mixed_case()
                         )
                     })
@@ -164,10 +156,9 @@ pub(crate) fn generate(
         blocked(f, |f| {
             // Write native elements
             for el in native_struct.elements() {
-                let java_type = JavaType(&el.element_type);
                 f.writeln(&format!(
                     "public {} {};",
-                    java_type.as_native_type(),
+                    el.element_type.as_native_type(),
                     el.name.to_mixed_case()
                 ))?;
             }
@@ -207,8 +198,7 @@ pub(crate) fn generate(
                 for el in native_struct.elements() {
                     let el_name = el.name.to_mixed_case();
 
-                    let java_type = JavaType(&el.element_type);
-                    if let Some(conversion) = java_type.conversion() {
+                    if let Some(conversion) = el.element_type.conversion() {
                         conversion.convert_to_native(
                             f,
                             &format!("self.{}", el_name),
@@ -233,8 +223,7 @@ pub(crate) fn generate(
                 for el in native_struct.elements() {
                     let el_name = el.name.to_mixed_case();
 
-                    let java_type = JavaType(&el.element_type);
-                    if let Some(conversion) = java_type.conversion() {
+                    if let Some(conversion) = el.element_type.conversion() {
                         conversion.convert_from_native(
                             f,
                             &format!("nativeStruct.{}", el_name),
@@ -256,8 +245,7 @@ pub(crate) fn generate(
                 for el in native_struct.elements() {
                     let el_name = el.name.to_mixed_case();
 
-                    let java_type = JavaType(&el.element_type);
-                    if let Some(conversion) = java_type.conversion() {
+                    if let Some(conversion) = el.element_type.conversion() {
                         conversion.convert_to_native_cleanup(f, &format!("this.{}", el_name))?;
                     }
                 }

--- a/oo-bindgen/Cargo.toml
+++ b/oo-bindgen/Cargo.toml
@@ -6,4 +6,6 @@ edition = "2018"
 
 [dependencies]
 thiserror = "1.0"
-semver = "0.10"
+semver = "0.11"
+regex = "1.3"
+lazy_static = "1.4"

--- a/oo-bindgen/src/callback.rs
+++ b/oo-bindgen/src/callback.rs
@@ -51,6 +51,10 @@ impl Interface {
             _ => None,
         })
     }
+
+    pub fn find_callback(&self, name: &str) -> Option<&CallbackFunction> {
+        self.callbacks().find(|callback| callback.name == name)
+    }
 }
 
 pub type InterfaceHandle = Handle<Interface>;
@@ -182,6 +186,10 @@ impl OneTimeCallback {
             OneTimeCallbackElement::CallbackFunction(cb) => Some(cb),
             _ => None,
         })
+    }
+
+    pub fn find_callback(&self, name: &str) -> Option<&CallbackFunction> {
+        self.callbacks().find(|callback| callback.name == name)
     }
 }
 

--- a/oo-bindgen/src/callback.rs
+++ b/oo-bindgen/src/callback.rs
@@ -1,4 +1,4 @@
-use crate::doc::Doc;
+use crate::doc::{Doc, DocString};
 use crate::*;
 use std::collections::HashSet;
 
@@ -318,7 +318,12 @@ impl<T: CallbackFunctionBuilderTarget> CallbackFunctionBuilder<T> {
         }
     }
 
-    pub fn param<D: Into<Doc>>(mut self, name: &str, param_type: Type, doc: D) -> Result<Self> {
+    pub fn param<D: Into<DocString>>(
+        mut self,
+        name: &str,
+        param_type: Type,
+        doc: D,
+    ) -> Result<Self> {
         self.target.lib().validate_type(&param_type)?;
         self.params.push(CallbackParameter::Parameter(Parameter {
             name: name.to_string(),

--- a/oo-bindgen/src/class.rs
+++ b/oo-bindgen/src/class.rs
@@ -1,3 +1,4 @@
+use crate::doc::DocString;
 use crate::*;
 
 /// C-style structure forward declaration
@@ -25,7 +26,7 @@ pub struct AsyncMethod {
     pub name: String,
     pub native_function: NativeFunctionHandle,
     pub return_type: Type,
-    pub return_type_doc: Doc,
+    pub return_type_doc: DocString,
     pub one_time_callback_name: String,
     pub one_time_callback_param_name: String,
     pub callback_name: String,
@@ -55,6 +56,28 @@ impl Class {
 
     pub fn is_static(&self) -> bool {
         self.constructor.is_none() && self.destructor.is_none() && self.methods.is_empty()
+    }
+
+    pub fn find_method(&self, method_name: &str) -> Option<&NativeFunctionHandle> {
+        for method in &self.methods {
+            if &method.name == method_name {
+                return Some(&method.native_function);
+            }
+        }
+
+        for method in &self.static_methods {
+            if &method.name == method_name {
+                return Some(&method.native_function);
+            }
+        }
+
+        for method in &self.async_methods {
+            if &method.name == method_name {
+                return Some(&method.native_function);
+            }
+        }
+
+        None
     }
 }
 

--- a/oo-bindgen/src/class.rs
+++ b/oo-bindgen/src/class.rs
@@ -60,19 +60,19 @@ impl Class {
 
     pub fn find_method(&self, method_name: &str) -> Option<&NativeFunctionHandle> {
         for method in &self.methods {
-            if &method.name == method_name {
+            if method.name == method_name {
                 return Some(&method.native_function);
             }
         }
 
         for method in &self.static_methods {
-            if &method.name == method_name {
+            if method.name == method_name {
                 return Some(&method.native_function);
             }
         }
 
         for method in &self.async_methods {
-            if &method.name == method_name {
+            if method.name == method_name {
                 return Some(&method.native_function);
             }
         }

--- a/oo-bindgen/src/doc.rs
+++ b/oo-bindgen/src/doc.rs
@@ -88,12 +88,18 @@ impl DocString {
     }
 }
 
+impl Default for DocString {
+    fn default() -> Self {
+        DocString::new()
+    }
+}
+
 impl From<&str> for DocString {
     fn from(mut from: &str) -> DocString {
         let mut result = DocString::new();
-        while let Some(start_idx) = from.find("{") {
+        while let Some(start_idx) = from.find('{') {
             let (before_str, current_str) = from.split_at(start_idx);
-            if let Some(end_idx) = current_str.find("}") {
+            if let Some(end_idx) = current_str.find('}') {
                 let (reference_str, current_str) = current_str.split_at(end_idx + 1);
                 let reference = DocReference::try_from(reference_str)
                     .expect("Invalid docstring: ill-formatted reference");

--- a/oo-bindgen/src/doc.rs
+++ b/oo-bindgen/src/doc.rs
@@ -1,97 +1,529 @@
-#[derive(Debug, Clone)]
-pub enum DocElement {
-    Text(String),
-    Reference(String),
-    Warning(String),
+use crate::native_function::Parameter;
+use crate::{BindingError, Library};
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::convert::TryFrom;
+
+pub fn doc<D: Into<DocString>>(brief: D) -> Doc {
+    Doc {
+        brief: brief.into(),
+        details: Vec::new(),
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct Doc {
-    content: Vec<DocElement>,
+    pub brief: DocString,
+    pub details: Vec<DocParagraph>,
 }
 
 impl Doc {
-    pub fn new(elements: Vec<DocElement>) -> Self {
-        Self { content: elements }
+    pub fn details<D: Into<DocString>>(mut self, details: D) -> Self {
+        self.details.push(DocParagraph::Details(details.into()));
+        self
     }
 
-    pub fn empty() -> Self {
-        Self {
-            content: Vec::new(),
-        }
+    pub fn warning<D: Into<DocString>>(mut self, warning: D) -> Self {
+        self.details.push(DocParagraph::Warning(warning.into()));
+        self
     }
 
-    pub fn text(content: &str) -> Self {
-        Self {
-            content: vec![DocElement::Text(content.to_owned())],
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.content.is_empty()
-    }
-}
-
-impl<'a> IntoIterator for &'a Doc {
-    type Item = &'a DocElement;
-    type IntoIter = std::slice::Iter<'a, DocElement>;
-    fn into_iter(self) -> Self::IntoIter {
-        self.content.iter()
-    }
-}
-
-impl Default for Doc {
-    fn default() -> Self {
-        Self::empty()
+    fn references(&self) -> impl Iterator<Item = &DocReference> {
+        self.brief
+            .references()
+            .chain(self.details.iter().flat_map(|para| para.references()))
     }
 }
 
 impl From<&str> for Doc {
     fn from(from: &str) -> Self {
-        Doc::text(from)
+        doc(from)
     }
 }
 
-pub struct DocBuilder {
-    elements: Vec<DocElement>,
+#[derive(Debug, Clone)]
+pub enum DocParagraph {
+    Details(DocString),
+    Warning(DocString),
 }
 
-impl DocBuilder {
+impl DocParagraph {
+    fn references(&self) -> impl Iterator<Item = &DocReference> {
+        match self {
+            Self::Details(string) => string.references(),
+            Self::Warning(string) => string.references(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DocString {
+    elements: Vec<DocStringElement>,
+}
+
+impl DocString {
     pub fn new() -> Self {
         Self {
             elements: Vec::new(),
         }
     }
 
-    pub fn build(self) -> Doc {
-        Doc::new(self.elements)
+    pub fn push(&mut self, element: DocStringElement) {
+        self.elements.push(element);
     }
 
-    pub fn text(mut self, text: &str) -> Self {
-        self.elements.push(DocElement::Text(text.to_owned()));
-        self
+    pub fn elements(&self) -> impl Iterator<Item = &DocStringElement> {
+        self.elements.iter()
     }
 
-    pub fn reference(mut self, typename: &str) -> Self {
-        self.elements
-            .push(DocElement::Reference(typename.to_owned()));
-        self
-    }
-
-    pub fn warn(mut self, text: &str) -> Self {
-        self.elements.push(DocElement::Warning(text.to_owned()));
-        self
+    fn references(&self) -> impl Iterator<Item = &DocReference> {
+        self.elements.iter().filter_map(|el| {
+            if let DocStringElement::Reference(reference) = el {
+                Some(reference)
+            } else {
+                None
+            }
+        })
     }
 }
 
-impl From<DocBuilder> for Doc {
-    fn from(from: DocBuilder) -> Self {
-        from.build()
+impl From<&str> for DocString {
+    fn from(mut from: &str) -> DocString {
+        let mut result = DocString::new();
+        while let Some(start_idx) = from.find("{") {
+            let (before_str, current_str) = from.split_at(start_idx);
+            if let Some(end_idx) = current_str.find("}") {
+                let (reference_str, current_str) = current_str.split_at(end_idx + 1);
+                let reference = DocReference::try_from(reference_str)
+                    .expect("Invalid docstring: ill-formatted reference");
+
+                if !before_str.is_empty() {
+                    result.push(DocStringElement::Text(before_str.to_owned()));
+                }
+                result.push(DocStringElement::Reference(reference));
+                from = current_str;
+            } else {
+                panic!("Invalid docstring: no end bracket");
+            }
+        }
+
+        // Add remaining string
+        if !from.is_empty() {
+            result.push(DocStringElement::Text(from.to_owned()));
+        }
+
+        result
     }
 }
 
-impl Default for DocBuilder {
-    fn default() -> Self {
-        Self::new()
+#[derive(Debug, Clone, PartialOrd, PartialEq)]
+pub enum DocStringElement {
+    Text(String),
+    Reference(DocReference),
+}
+
+#[derive(Debug, Clone, PartialOrd, PartialEq)]
+pub enum DocReference {
+    /// Reference to a parameter
+    Param(String),
+    /// Reference a class
+    Class(String),
+    /// Reference a class method
+    ///
+    /// First string is the class name, second is the method's name
+    ClassMethod(String, String),
+    /// Reference a struct
+    Struct(String),
+    /// Reference an element in a struct
+    ///
+    /// First string is the struct name, second is the element name inside that struct
+    StructElement(String, String),
+    /// Reference a method of a struct
+    ///
+    /// First string is the struct name, second is the method's name
+    StructMethod(String, String),
+    /// Reference an enum
+    Enum(String),
+    /// Reference an enum variant
+    ///
+    /// First string is the enum name, second is the enum variant name
+    EnumVariant(String, String),
+}
+
+impl TryFrom<&str> for DocReference {
+    type Error = BindingError;
+
+    fn try_from(from: &str) -> Result<DocReference, BindingError> {
+        lazy_static! {
+            static ref RE_PARAM: Regex = Regex::new(r"\{param:([[:word:]]+)\}").unwrap();
+            static ref RE_CLASS: Regex = Regex::new(r"\{class:([[:word:]]+)\}").unwrap();
+            static ref RE_CLASS_METHOD: Regex =
+                Regex::new(r"\{class:([[:word:]]+)\.([[:word:]]+)\(\)\}").unwrap();
+            static ref RE_STRUCT: Regex = Regex::new(r"\{struct:([[:word:]]+)\}").unwrap();
+            static ref RE_STRUCT_ELEMENT: Regex =
+                Regex::new(r"\{struct:([[:word:]]+)\.([[:word:]]+)\}").unwrap();
+            static ref RE_STRUCT_METHOD: Regex =
+                Regex::new(r"\{struct:([[:word:]]+)\.([[:word:]]+)\(\)\}").unwrap();
+            static ref RE_ENUM: Regex = Regex::new(r"\{enum:([[:word:]]+)\}").unwrap();
+            static ref RE_ENUM_VARIANT: Regex =
+                Regex::new(r"\{enum:([[:word:]]+)\.([[:word:]]+)\}").unwrap();
+        }
+
+        if let Some(capture) = RE_PARAM.captures(from) {
+            return Ok(DocReference::Param(
+                capture.get(1).unwrap().as_str().to_owned(),
+            ));
+        }
+        if let Some(capture) = RE_CLASS.captures(from) {
+            return Ok(DocReference::Class(
+                capture.get(1).unwrap().as_str().to_owned(),
+            ));
+        }
+        if let Some(capture) = RE_CLASS_METHOD.captures(from) {
+            return Ok(DocReference::ClassMethod(
+                capture.get(1).unwrap().as_str().to_owned(),
+                capture.get(2).unwrap().as_str().to_owned(),
+            ));
+        }
+        if let Some(capture) = RE_STRUCT.captures(from) {
+            return Ok(DocReference::Struct(
+                capture.get(1).unwrap().as_str().to_owned(),
+            ));
+        }
+        if let Some(capture) = RE_STRUCT_ELEMENT.captures(from) {
+            return Ok(DocReference::StructElement(
+                capture.get(1).unwrap().as_str().to_owned(),
+                capture.get(2).unwrap().as_str().to_owned(),
+            ));
+        }
+        if let Some(capture) = RE_STRUCT_METHOD.captures(from) {
+            return Ok(DocReference::StructMethod(
+                capture.get(1).unwrap().as_str().to_owned(),
+                capture.get(2).unwrap().as_str().to_owned(),
+            ));
+        }
+        if let Some(capture) = RE_ENUM.captures(from) {
+            return Ok(DocReference::Enum(
+                capture.get(1).unwrap().as_str().to_owned(),
+            ));
+        }
+        if let Some(capture) = RE_ENUM_VARIANT.captures(from) {
+            return Ok(DocReference::EnumVariant(
+                capture.get(1).unwrap().as_str().to_owned(),
+                capture.get(2).unwrap().as_str().to_owned(),
+            ));
+        }
+
+        Err(BindingError::InvalidDocString)
+    }
+}
+
+pub(crate) fn validate_library_docs(lib: &Library) -> Result<(), BindingError> {
+    for native_function in lib.native_functions() {
+        validate_doc_with_params(
+            &native_function.name,
+            &native_function.doc,
+            &native_function.parameters,
+            lib,
+        )?;
+    }
+
+    for class in lib.classes() {
+        validate_doc(class.name(), &class.doc, lib)?;
+    }
+
+    Ok(())
+}
+
+fn validate_doc(symbol_name: &str, doc: &Doc, lib: &Library) -> Result<(), BindingError> {
+    validate_doc_with_params(symbol_name, doc, &[], lib)
+}
+
+fn validate_doc_with_params(
+    symbol_name: &str,
+    doc: &Doc,
+    params: &[Parameter],
+    lib: &Library,
+) -> Result<(), BindingError> {
+    for reference in doc.references() {
+        match reference {
+            DocReference::Param(param_name) => {
+                if params
+                    .iter()
+                    .find(|param| &param.name == param_name)
+                    .is_none()
+                {
+                    return Err(BindingError::DocInvalidReference {
+                        symbol_name: symbol_name.to_string(),
+                        ref_name: param_name.to_string(),
+                    });
+                }
+            }
+            DocReference::Class(class_name) => {
+                if lib.find_class(class_name).is_none() {
+                    return Err(BindingError::DocInvalidReference {
+                        symbol_name: symbol_name.to_string(),
+                        ref_name: class_name.to_string(),
+                    });
+                }
+            }
+            DocReference::ClassMethod(class_name, method_name) => {
+                if let Some(handle) = lib.find_class(class_name) {
+                    if handle.find_method(method_name).is_none() {
+                        return Err(BindingError::DocInvalidReference {
+                            symbol_name: symbol_name.to_string(),
+                            ref_name: format!(
+                                "{}.{}()",
+                                class_name.to_string(),
+                                method_name.to_string()
+                            ),
+                        });
+                    }
+                } else {
+                    return Err(BindingError::DocInvalidReference {
+                        symbol_name: symbol_name.to_string(),
+                        ref_name: format!(
+                            "{}.{}()",
+                            class_name.to_string(),
+                            method_name.to_string()
+                        ),
+                    });
+                }
+            }
+            DocReference::Struct(struct_name) => {
+                if lib.find_struct(struct_name).is_none() {
+                    return Err(BindingError::DocInvalidReference {
+                        symbol_name: symbol_name.to_string(),
+                        ref_name: struct_name.to_string(),
+                    });
+                }
+            }
+            DocReference::StructElement(struct_name, method_name) => {
+                if let Some(handle) = lib.find_struct(struct_name) {
+                    if handle.find_element(method_name).is_none() {
+                        return Err(BindingError::DocInvalidReference {
+                            symbol_name: symbol_name.to_string(),
+                            ref_name: format!(
+                                "{}.{}",
+                                struct_name.to_string(),
+                                method_name.to_string()
+                            ),
+                        });
+                    }
+                } else {
+                    return Err(BindingError::DocInvalidReference {
+                        symbol_name: symbol_name.to_string(),
+                        ref_name: format!(
+                            "{}.{}",
+                            struct_name.to_string(),
+                            method_name.to_string()
+                        ),
+                    });
+                }
+            }
+            DocReference::StructMethod(struct_name, element_name) => {
+                if let Some(handle) = lib.find_struct(struct_name) {
+                    if handle.find_method(element_name).is_none() {
+                        return Err(BindingError::DocInvalidReference {
+                            symbol_name: symbol_name.to_string(),
+                            ref_name: format!(
+                                "{}.{}()",
+                                struct_name.to_string(),
+                                element_name.to_string()
+                            ),
+                        });
+                    }
+                } else {
+                    return Err(BindingError::DocInvalidReference {
+                        symbol_name: symbol_name.to_string(),
+                        ref_name: format!(
+                            "{}.{}()",
+                            struct_name.to_string(),
+                            element_name.to_string()
+                        ),
+                    });
+                }
+            }
+            DocReference::Enum(enum_name) => {
+                if lib.find_enum(enum_name).is_none() {
+                    return Err(BindingError::DocInvalidReference {
+                        symbol_name: symbol_name.to_string(),
+                        ref_name: enum_name.to_string(),
+                    });
+                }
+            }
+            DocReference::EnumVariant(enum_name, variant_name) => {
+                if let Some(handle) = lib.find_enum(enum_name) {
+                    if handle.find_variant(variant_name).is_none() {
+                        return Err(BindingError::DocInvalidReference {
+                            symbol_name: symbol_name.to_string(),
+                            ref_name: format!(
+                                "{}.{}",
+                                enum_name.to_string(),
+                                variant_name.to_string()
+                            ),
+                        });
+                    }
+                } else {
+                    return Err(BindingError::DocInvalidReference {
+                        symbol_name: symbol_name.to_string(),
+                        ref_name: format!("{}.{}", enum_name.to_string(), variant_name.to_string()),
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::convert::TryInto;
+
+    #[test]
+    fn parse_param_reference() {
+        let doc: DocString = "This is a {param:foo} test.".try_into().unwrap();
+        assert_eq!(
+            [
+                DocStringElement::Text("This is a ".to_owned()),
+                DocStringElement::Reference(DocReference::Param("foo".to_owned())),
+                DocStringElement::Text(" test.".to_owned()),
+            ]
+            .as_ref(),
+            doc.elements.as_slice()
+        );
+    }
+
+    #[test]
+    fn parse_class_reference() {
+        let doc: DocString = "This is a {class:MyClass} test.".try_into().unwrap();
+        assert_eq!(
+            [
+                DocStringElement::Text("This is a ".to_owned()),
+                DocStringElement::Reference(DocReference::Class("MyClass".to_owned())),
+                DocStringElement::Text(" test.".to_owned()),
+            ]
+            .as_ref(),
+            doc.elements.as_slice()
+        );
+    }
+
+    #[test]
+    fn parse_class_reference_at_the_end() {
+        let doc: DocString = "This is a test {class:MyClass2}".try_into().unwrap();
+        assert_eq!(
+            [
+                DocStringElement::Text("This is a test ".to_owned()),
+                DocStringElement::Reference(DocReference::Class("MyClass2".to_owned())),
+            ]
+            .as_ref(),
+            doc.elements.as_slice()
+        );
+    }
+
+    #[test]
+    fn parse_class_method() {
+        let doc: DocString = "This is a {class:MyClass.do_something()} method."
+            .try_into()
+            .unwrap();
+        assert_eq!(
+            [
+                DocStringElement::Text("This is a ".to_owned()),
+                DocStringElement::Reference(DocReference::ClassMethod(
+                    "MyClass".to_owned(),
+                    "do_something".to_owned()
+                )),
+                DocStringElement::Text(" method.".to_owned()),
+            ]
+            .as_ref(),
+            doc.elements.as_slice()
+        );
+    }
+
+    #[test]
+    fn parse_struct() {
+        let doc: DocString = "This is a {struct:MyStruct} struct.".try_into().unwrap();
+        assert_eq!(
+            [
+                DocStringElement::Text("This is a ".to_owned()),
+                DocStringElement::Reference(DocReference::Struct("MyStruct".to_owned())),
+                DocStringElement::Text(" struct.".to_owned()),
+            ]
+            .as_ref(),
+            doc.elements.as_slice()
+        );
+    }
+
+    #[test]
+    fn parse_struct_element() {
+        let doc: DocString = "This is a {struct:MyStruct.foo} struct element."
+            .try_into()
+            .unwrap();
+        assert_eq!(
+            [
+                DocStringElement::Text("This is a ".to_owned()),
+                DocStringElement::Reference(DocReference::StructElement(
+                    "MyStruct".to_owned(),
+                    "foo".to_owned()
+                )),
+                DocStringElement::Text(" struct element.".to_owned()),
+            ]
+            .as_ref(),
+            doc.elements.as_slice()
+        );
+    }
+
+    #[test]
+    fn parse_struct_method() {
+        let doc: DocString = "This is a {struct:MyStruct.bar()} struct method."
+            .try_into()
+            .unwrap();
+        assert_eq!(
+            [
+                DocStringElement::Text("This is a ".to_owned()),
+                DocStringElement::Reference(DocReference::StructMethod(
+                    "MyStruct".to_owned(),
+                    "bar".to_owned()
+                )),
+                DocStringElement::Text(" struct method.".to_owned()),
+            ]
+            .as_ref(),
+            doc.elements.as_slice()
+        );
+    }
+
+    #[test]
+    fn parse_enum() {
+        let doc: DocString = "This is a {enum:MyEnum} enum.".try_into().unwrap();
+        assert_eq!(
+            [
+                DocStringElement::Text("This is a ".to_owned()),
+                DocStringElement::Reference(DocReference::Enum("MyEnum".to_owned())),
+                DocStringElement::Text(" enum.".to_owned()),
+            ]
+            .as_ref(),
+            doc.elements.as_slice()
+        );
+    }
+
+    #[test]
+    fn parse_enum_element() {
+        let doc: DocString = "This is a {enum:MyEnum.foo} enum variant."
+            .try_into()
+            .unwrap();
+        assert_eq!(
+            [
+                DocStringElement::Text("This is a ".to_owned()),
+                DocStringElement::Reference(DocReference::EnumVariant(
+                    "MyEnum".to_owned(),
+                    "foo".to_owned()
+                )),
+                DocStringElement::Text(" enum variant.".to_owned()),
+            ]
+            .as_ref(),
+            doc.elements.as_slice()
+        );
     }
 }

--- a/oo-bindgen/src/lib.rs
+++ b/oo-bindgen/src/lib.rs
@@ -407,11 +407,37 @@ impl Library {
         })
     }
 
+    pub fn find_interface(&self, name: &str) -> Option<&InterfaceHandle> {
+        self.symbol(name)
+            .iter()
+            .filter_map(|symbol| {
+                if let Symbol::Interface(handle) = symbol {
+                    Some(handle)
+                } else {
+                    None
+                }
+            })
+            .next()
+    }
+
     pub fn one_time_callbacks(&self) -> impl Iterator<Item = &OneTimeCallbackHandle> {
         self.into_iter().filter_map(|statement| match statement {
             Statement::OneTimeCallbackDefinition(handle) => Some(handle),
             _ => None,
         })
+    }
+
+    pub fn find_one_time_callback(&self, name: &str) -> Option<&OneTimeCallbackHandle> {
+        self.symbol(name)
+            .iter()
+            .filter_map(|symbol| {
+                if let Symbol::OneTimeCallback(handle) = symbol {
+                    Some(handle)
+                } else {
+                    None
+                }
+            })
+            .next()
     }
 
     pub fn symbol(&self, symbol_name: &str) -> Option<&Symbol> {

--- a/oo-bindgen/src/native_enum.rs
+++ b/oo-bindgen/src/native_enum.rs
@@ -15,6 +15,14 @@ pub struct NativeEnum {
     pub doc: Doc,
 }
 
+impl NativeEnum {
+    pub fn find_variant(&self, variant_name: &str) -> Option<&EnumVariant> {
+        self.variants
+            .iter()
+            .find(|variant| variant.name == variant_name)
+    }
+}
+
 pub type NativeEnumHandle = Handle<NativeEnum>;
 
 pub struct NativeEnumBuilder<'a> {

--- a/oo-bindgen/src/native_function.rs
+++ b/oo-bindgen/src/native_function.rs
@@ -1,5 +1,5 @@
 use crate::collection::CollectionHandle;
-use crate::doc::Doc;
+use crate::doc::{Doc, DocString};
 use crate::iterator::IteratorHandle;
 use crate::*;
 
@@ -45,7 +45,7 @@ pub enum DurationMapping {
 #[derive(Debug)]
 pub enum ReturnType {
     Void,
-    Type(Type, Doc),
+    Type(Type, DocString),
 }
 
 impl ReturnType {
@@ -53,7 +53,7 @@ impl ReturnType {
         ReturnType::Void
     }
 
-    pub fn new<D: Into<Doc>>(return_type: Type, doc: D) -> Self {
+    pub fn new<D: Into<DocString>>(return_type: Type, doc: D) -> Self {
         ReturnType::Type(return_type, doc.into())
     }
 
@@ -69,7 +69,7 @@ impl ReturnType {
 pub struct Parameter {
     pub name: String,
     pub param_type: Type,
-    pub doc: Doc,
+    pub doc: DocString,
 }
 
 /// C function
@@ -102,7 +102,12 @@ impl<'a> NativeFunctionBuilder<'a> {
         }
     }
 
-    pub fn param<D: Into<Doc>>(mut self, name: &str, param_type: Type, doc: D) -> Result<Self> {
+    pub fn param<D: Into<DocString>>(
+        mut self,
+        name: &str,
+        param_type: Type,
+        doc: D,
+    ) -> Result<Self> {
         self.lib.validate_type(&param_type)?;
         self.params.push(Parameter {
             name: name.to_string(),

--- a/oo-bindgen/src/native_function.rs
+++ b/oo-bindgen/src/native_function.rs
@@ -65,7 +65,7 @@ impl ReturnType {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Parameter {
     pub name: String,
     pub param_type: Type,

--- a/oo-bindgen/src/native_struct.rs
+++ b/oo-bindgen/src/native_struct.rs
@@ -159,6 +159,26 @@ impl Struct {
     pub fn doc(&self) -> &Doc {
         &self.definition.doc
     }
+
+    pub fn find_method(&self, method_name: &str) -> Option<&NativeFunctionHandle> {
+        for method in &self.methods {
+            if method.name == method_name {
+                return Some(&method.native_function);
+            }
+        }
+
+        for method in &self.static_methods {
+            if method.name == method_name {
+                return Some(&method.native_function);
+            }
+        }
+
+        None
+    }
+
+    pub fn find_element(&self, element_name: &str) -> Option<&NativeStructElement> {
+        self.elements().find(|el| el.name == element_name)
+    }
 }
 
 pub type StructHandle = Handle<Struct>;

--- a/tests/foo-schema/src/callback.rs
+++ b/tests/foo-schema/src/callback.rs
@@ -7,7 +7,7 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
         .define_interface("CallbackInterface", "Test interface")?
         .callback("on_value", "On value callback")?
         .param("value", Type::Uint32, "Value")?
-        .return_type(ReturnType::Type(Type::Uint32, "Some value".into()))?
+        .return_type(ReturnType::new(Type::Uint32, "Some value"))?
         .build()?
         .callback("on_duration", "On duration callback")?
         .param(
@@ -15,9 +15,9 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
             Type::Duration(DurationMapping::Milliseconds),
             "Value",
         )?
-        .return_type(ReturnType::Type(
+        .return_type(ReturnType::new(
             Type::Duration(DurationMapping::Milliseconds),
-            "Some value".into(),
+            "Some value",
         ))?
         .build()?
         .destroy_callback("on_destroy")?
@@ -27,7 +27,7 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
         .define_one_time_callback("OneTimeCallbackInterface", "Test one-time-interface")?
         .callback("on_value", "On value callback")?
         .param("value", Type::Uint32, "Value")?
-        .return_type(ReturnType::Type(Type::Uint32, "Some value".into()))?
+        .return_type(ReturnType::new(Type::Uint32, "Some value"))?
         .build()?
         .build()?;
 
@@ -79,9 +79,9 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
             Type::OneTimeCallback(one_time_callback),
             "Callback to add",
         )?
-        .return_type(ReturnType::Type(
+        .return_type(ReturnType::new(
             Type::Uint32,
-            "Value returned by the callback".into(),
+            "Value returned by the callback",
         ))?
         .doc("Add a one-time callback")?
         .build()?;
@@ -94,9 +94,9 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
             "Callback source",
         )?
         .param("value", Type::Uint32, "New value")?
-        .return_type(ReturnType::Type(
+        .return_type(ReturnType::new(
             Type::Uint32,
-            "Value returned by the callback".into(),
+            "Value returned by the callback",
         ))?
         .doc("Set the value and call all the callbacks")?
         .build()?;
@@ -113,9 +113,9 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
             Type::Duration(DurationMapping::Milliseconds),
             "New duration",
         )?
-        .return_type(ReturnType::Type(
+        .return_type(ReturnType::new(
             Type::Duration(DurationMapping::Milliseconds),
-            "Some value".into(),
+            "Some value",
         ))?
         .doc("Set the duration and call all the callbacks")?
         .build()?;

--- a/tests/foo-schema/src/class.rs
+++ b/tests/foo-schema/src/class.rs
@@ -16,10 +16,12 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
         .doc(
             doc("Create a new {class:TestClass}")
                 .details("Here are some details about {class:TestClass}. You can call {class:TestClass.GetValue()} method.")
+                .details("Here is a reference to a constructor {class:TestClass.[constructor]} and to a destructor {class:TestClass.[destructor]}.")
                 .details("Here are some details about the struct {struct:Structure}. It has the {struct:Structure.boolean_value} element and the {struct:Structure.StructByValueEcho()} method." )
                 .details("Here are some details about {enum:EnumZeroToFive}. It has the {enum:EnumZeroToFive.Two} variant.")
                 .details("Here are some details about {interface:CallbackInterface}. It has the {interface:CallbackInterface.on_value()} callback.")
                 .details("Here are some details about {callback:OneTimeCallbackInterface}. It has the {callback:OneTimeCallbackInterface.on_value()} callback.")
+                .details("Here's a {null}. Here's the {iterator}.")
                 .warning("And here's a dangerous warning! Do not use {class:TestClass.GetValue()}"),
         )?
         .build()?;

--- a/tests/foo-schema/src/class.rs
+++ b/tests/foo-schema/src/class.rs
@@ -16,8 +16,10 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
         .doc(
             doc("Create a new {class:TestClass}")
                 .details("Here are some details about {class:TestClass}. You can call {class:TestClass.GetValue()} method.")
-                .details("Here are some details about the struct {struct:Structure}. It has the {struct:Structure.boolean_value} and the {struct:Structure.StructByValueEcho()} method." )
+                .details("Here are some details about the struct {struct:Structure}. It has the {struct:Structure.boolean_value} element and the {struct:Structure.StructByValueEcho()} method." )
                 .details("Here are some details about {enum:EnumZeroToFive}. It has the {enum:EnumZeroToFive.Two} variant.")
+                .details("Here are some details about {interface:CallbackInterface}. It has the {interface:CallbackInterface.on_value()} callback.")
+                .details("Here are some details about {callback:OneTimeCallbackInterface}. It has the {callback:OneTimeCallbackInterface.on_value()} callback.")
                 .warning("And here's a dangerous warning! Do not use {class:TestClass.GetValue()}"),
         )?
         .build()?;
@@ -41,7 +43,7 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
             "TestClass handle",
         )?
         .return_type(ReturnType::new(Type::Uint32, "Current value"))?
-        .doc("Get value")?
+        .doc("Get value (don't forget the {param:testclass}!)")?
         .build()?;
 
     let testclass_increment_value_func = lib

--- a/tests/foo-schema/src/class.rs
+++ b/tests/foo-schema/src/class.rs
@@ -13,7 +13,13 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
             Type::ClassRef(testclass.clone()),
             "New TestClass",
         ))?
-        .doc("Create a new TestClass")?
+        .doc(
+            doc("Create a new {class:TestClass}")
+                .details("Here are some details about {class:TestClass}. You can call {class:TestClass.GetValue()} method.")
+                .details("Here are some details about the struct {struct:Structure}. It has the {struct:Structure.boolean_value} and the {struct:Structure.StructByValueEcho()} method." )
+                .details("Here are some details about {enum:EnumZeroToFive}. It has the {enum:EnumZeroToFive.Two} variant.")
+                .warning("And here's a dangerous warning! Do not use {class:TestClass.GetValue()}"),
+        )?
         .build()?;
 
     let testclass_destroy_func = lib

--- a/tests/foo-schema/src/lib.rs
+++ b/tests/foo-schema/src/lib.rs
@@ -37,5 +37,15 @@ pub fn build_lib() -> Result<Library, BindingError> {
     lifetime::define(&mut builder)?;
     collection::define(&mut builder)?;
 
-    Ok(builder.build())
+    builder.build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_lib() {
+        build_lib().unwrap();
+    }
 }


### PR DESCRIPTION
Documentation is now split in two; the `Doc` contains the mandatory brief description and optional details paragraph. The `DocString` represents a single paragraph of text. It can parse references and create hyperlinks in the generated doc. All the references are checked when creating the library and an error will be returned if a reference cannot be resolved.

When a `Doc` is needed, the user can provide a string and it will automatically be parsed and interpreted as just a brief description. If additional details are needed, then the user may use the `doc()` function to build a more complex documentation. The `doc()` functions takes the brief string as a parameter, then can be chained with `details()` to add details paragraph or with `warning()` to add a warning paragraph.

For parameters, only a `DocString` is accepted, because some generators do not support paragraphs for parameters.

### References

In any `DocString`, you can put references that will print a hyperlink in the generated doc. You simply put the reference between curly braces and the `DocString` parser will resolve them. All the names used must match exactly what is specified __in the schema__, each generator takes care of the renaming the type for the target language.

Here are all the type of links available:
- `{param:MyParam}`: references the parameter `MyParam` of a method. __This is only valid within a method documentation__. Not all documentation generator supports hyperlinking this, so `code font` is used instead.
- `{class:MyClass}`: references the class `MyClass`.
- `{class:MyClass.foo()}`: references the method `foo()` of `MyClass`. Can be a static, non-static, or async method. No need to put parameters. 
- `{class:MyClass.[constructor]}`: references `MyClass`'s constructor.
- `{class:MyClass.[destructor]}`: references `MyClass`'s destructor (the `Dispose()` method in C#, the `close()` method in Java).
- `{struct:MyStruct}`: references the structure `MyStruct`.
- `{struct:MyStruct.foo}`: references the `foo` element inside `MyStruct`.
- `{struct:MyStruct.foo()}`: references the `foo()` method of `MyStruct`. Can be a static or non-static method. No need to put parameters.
- `{enum:MyEnum}`: references the enum `MyEnum`.
- `{enum:MyEnum.foo}`: references the `foo` variant of `MyEnum`.
- `{interface:MyInterface}`: references the interface `MyInterface`.
- `{interface:MyInterface.foo()}`: references the `foo()` callback of `MyInterface`. This cannot reference the `on_destroy` callback.
- `{callback:MyOneTimeCallback}`: references the interface `MyOneTimeCallback`.
- `{callback:MyOneTimeCallback.foo()}`: references the `foo()` callback of `MyOneTimeCallback`.

There other miscellaneous tag that can be used:
- `{null}`: prints `NULL` in C, or `null` in C# and Java.
- `{iterator}`: prints `iterator` in C, or `collection` in C# and Java.

Fix #14 and #27.