### PR TITLE
Add structure default constructors

### DIFF
--- a/generators/c-oo-bindgen/src/doc.rs
+++ b/generators/c-oo-bindgen/src/doc.rs
@@ -54,7 +54,7 @@ fn reference_print(
         }
         DocReference::Class(class_name) => {
             let handle = lib.find_class_declaration(class_name).unwrap();
-            f.write(&format!("@ref {}", handle.to_type()))?;
+            f.write(&format!("@ref {}", handle.to_c_type()))?;
         }
         DocReference::ClassMethod(class_name, method_name) => {
             let func_name = &lib
@@ -81,7 +81,7 @@ fn reference_print(
         }
         DocReference::Struct(struct_name) => {
             let struct_name = lib.find_struct(struct_name).unwrap().declaration();
-            f.write(&format!("@ref {}", struct_name.to_type()))?;
+            f.write(&format!("@ref {}", struct_name.to_c_type()))?;
         }
         DocReference::StructMethod(struct_name, method_name) => {
             let func_name = &lib
@@ -96,13 +96,13 @@ fn reference_print(
             let handle = lib.find_struct(struct_name).unwrap();
             f.write(&format!(
                 "@ref {}.{}",
-                handle.definition().to_type(),
+                handle.definition().to_c_type(),
                 element_name.to_snake_case()
             ))?;
         }
         DocReference::Enum(enum_name) => {
             let enum_name = lib.find_enum(enum_name).unwrap();
-            f.write(&format!("@ref {}", enum_name.to_type()))?;
+            f.write(&format!("@ref {}", enum_name.to_c_type()))?;
         }
         DocReference::EnumVariant(enum_name, variant_name) => {
             let handle = lib.find_enum(enum_name).unwrap();
@@ -114,25 +114,25 @@ fn reference_print(
         }
         DocReference::Interface(interface_name) => {
             let handle = lib.find_interface(interface_name).unwrap();
-            f.write(&format!("@ref {}", handle.to_type()))?;
+            f.write(&format!("@ref {}", handle.to_c_type()))?;
         }
         DocReference::InterfaceMethod(interface_name, callback_name) => {
             let handle = &lib.find_interface(interface_name).unwrap();
             f.write(&format!(
                 "@ref {}.{}",
-                handle.to_type(),
+                handle.to_c_type(),
                 callback_name.to_snake_case()
             ))?;
         }
         DocReference::OneTimeCallback(interface_name) => {
             let handle = lib.find_one_time_callback(interface_name).unwrap();
-            f.write(&format!("@ref {}", handle.to_type()))?;
+            f.write(&format!("@ref {}", handle.to_c_type()))?;
         }
         DocReference::OneTimeCallbackMethod(interface_name, callback_name) => {
             let handle = &lib.find_one_time_callback(interface_name).unwrap();
             f.write(&format!(
                 "@ref {}.{}",
-                handle.to_type(),
+                handle.to_c_type(),
                 callback_name.to_snake_case()
             ))?;
         }

--- a/generators/c-oo-bindgen/src/lib.rs
+++ b/generators/c-oo-bindgen/src/lib.rs
@@ -66,56 +66,56 @@ mod doc;
 mod formatting;
 
 trait CFormatting {
-    fn to_type(&self) -> String;
+    fn to_c_type(&self) -> String;
 }
 
 impl CFormatting for NativeStructDeclarationHandle {
-    fn to_type(&self) -> String {
+    fn to_c_type(&self) -> String {
         format!("{}_t", self.name.to_snake_case())
     }
 }
 
 impl CFormatting for NativeStructHandle {
-    fn to_type(&self) -> String {
+    fn to_c_type(&self) -> String {
         format!("{}_t", self.name().to_snake_case())
     }
 }
 
 impl CFormatting for NativeEnumHandle {
-    fn to_type(&self) -> String {
+    fn to_c_type(&self) -> String {
         format!("{}_t", self.name.to_snake_case())
     }
 }
 
 impl CFormatting for ClassDeclarationHandle {
-    fn to_type(&self) -> String {
+    fn to_c_type(&self) -> String {
         format!("{}_t", self.name.to_snake_case())
     }
 }
 
 impl CFormatting for Interface {
-    fn to_type(&self) -> String {
+    fn to_c_type(&self) -> String {
         format!("{}_t", self.name.to_snake_case())
     }
 }
 
 impl CFormatting for OneTimeCallbackHandle {
-    fn to_type(&self) -> String {
+    fn to_c_type(&self) -> String {
         format!("{}_t", self.name.to_snake_case())
     }
 }
 
 impl CFormatting for Symbol {
-    fn to_type(&self) -> String {
+    fn to_c_type(&self) -> String {
         match self {
             Symbol::NativeFunction(handle) => handle.name.to_owned(),
-            Symbol::Struct(handle) => handle.declaration().to_type(),
-            Symbol::Enum(handle) => handle.to_type(),
-            Symbol::Class(handle) => handle.declaration().to_type(),
-            Symbol::Interface(handle) => handle.to_type(),
-            Symbol::OneTimeCallback(handle) => handle.to_type(),
-            Symbol::Iterator(handle) => handle.iter_type.to_type(),
-            Symbol::Collection(handle) => handle.collection_type.to_type(),
+            Symbol::Struct(handle) => handle.declaration().to_c_type(),
+            Symbol::Enum(handle) => handle.to_c_type(),
+            Symbol::Class(handle) => handle.declaration().to_c_type(),
+            Symbol::Interface(handle) => handle.to_c_type(),
+            Symbol::OneTimeCallback(handle) => handle.to_c_type(),
+            Symbol::Iterator(handle) => handle.iter_type.to_c_type(),
+            Symbol::Collection(handle) => handle.collection_type.to_c_type(),
         }
     }
 }
@@ -246,8 +246,8 @@ fn generate_c_header<P: AsRef<Path>>(lib: &Library, path: P) -> FormattingResult
                 Statement::NativeStructDeclaration(handle) => {
                     f.writeln(&format!(
                         "typedef struct {} {};",
-                        handle.to_type(),
-                        handle.to_type()
+                        handle.to_c_type(),
+                        handle.to_c_type()
                     ))?;
                 }
                 Statement::NativeStructDefinition(handle) => {
@@ -276,13 +276,48 @@ fn write_struct_definition(
 ) -> FormattingResult<()> {
     doxygen(f, |f| doxygen_print(f, &handle.doc, lib))?;
 
-    f.writeln(&format!("typedef struct {}", handle.to_type()))?;
+    // Write the struct definition
+    f.writeln(&format!("typedef struct {}", handle.to_c_type()))?;
     f.writeln("{")?;
     indented(f, |f| {
         for element in &handle.elements {
             doxygen(f, |f| {
-                f.newline()?;
                 doxygen_print(f, &element.doc, lib)?;
+
+                let default_value = match &element.element_type {
+                    StructElementType::Bool(default) => default.map(|x| x.to_string()),
+                    StructElementType::Uint8(default) => default.map(|x| x.to_string()),
+                    StructElementType::Sint8(default) => default.map(|x| x.to_string()),
+                    StructElementType::Uint16(default) => default.map(|x| x.to_string()),
+                    StructElementType::Sint16(default) => default.map(|x| x.to_string()),
+                    StructElementType::Uint32(default) => default.map(|x| x.to_string()),
+                    StructElementType::Sint32(default) => default.map(|x| x.to_string()),
+                    StructElementType::Uint64(default) => default.map(|x| x.to_string()),
+                    StructElementType::Sint64(default) => default.map(|x| x.to_string()),
+                    StructElementType::Float(default) => default.map(|x| x.to_string()),
+                    StructElementType::Double(default) => default.map(|x| x.to_string()),
+                    StructElementType::String(default) => {
+                        default.clone().map(|x| format!("\"{}\"", x))
+                    }
+                    StructElementType::Struct(_) => None,
+                    StructElementType::StructRef(_) => None,
+                    StructElementType::Enum(handle, default) => default.clone().map(|x| {
+                        format!("@ref {}_{}", handle.name.to_camel_case(), x.to_camel_case())
+                    }),
+                    StructElementType::ClassRef(_) => None,
+                    StructElementType::Interface(_) => None,
+                    StructElementType::OneTimeCallback(_) => None,
+                    StructElementType::Iterator(_) => None,
+                    StructElementType::Collection(_) => None,
+                    StructElementType::Duration(_, default) => {
+                        default.map(|x| format!("{}s", x.as_secs_f32()))
+                    }
+                };
+
+                if let Some(default_value) = default_value {
+                    f.writeln(&format!("@note Default value is {}", default_value))?;
+                }
+
                 Ok(())
             })?;
             f.writeln(&format!(
@@ -293,7 +328,126 @@ fn write_struct_definition(
         }
         Ok(())
     })?;
-    f.writeln(&format!("}} {};", handle.to_type()))
+    f.writeln(&format!("}} {};", handle.to_c_type()))?;
+
+    // Write the struct initializer
+    let params = handle
+        .elements()
+        .filter(|el| !el.element_type.has_default())
+        .map(|el| {
+            format!(
+                "{} {}",
+                CType(&el.element_type.to_type()),
+                el.name.to_snake_case()
+            )
+        })
+        .collect::<Vec<String>>()
+        .join(", ");
+
+    f.newline()?;
+
+    f.writeln(&format!(
+        "static {} {}_init({})",
+        handle.to_c_type(),
+        handle.name().to_snake_case(),
+        params
+    ))?;
+    blocked(f, |f| {
+        f.writeln(&format!("return ({})", handle.to_c_type()))?;
+        f.writeln("{")?;
+        indented(f, |f| {
+            for el in handle.elements() {
+                let value = match &el.element_type {
+                    StructElementType::Bool(default) => match default {
+                        None => el.name.to_snake_case(),
+                        Some(false) => "false".to_string(),
+                        Some(true) => "true".to_string(),
+                    },
+                    StructElementType::Uint8(default) => match default {
+                        None => el.name.to_snake_case(),
+                        Some(value) => value.to_string(),
+                    },
+                    StructElementType::Sint8(default) => match default {
+                        None => el.name.to_snake_case(),
+                        Some(value) => value.to_string(),
+                    },
+                    StructElementType::Uint16(default) => match default {
+                        None => el.name.to_snake_case(),
+                        Some(value) => value.to_string(),
+                    },
+                    StructElementType::Sint16(default) => match default {
+                        None => el.name.to_snake_case(),
+                        Some(value) => value.to_string(),
+                    },
+                    StructElementType::Uint32(default) => match default {
+                        None => el.name.to_snake_case(),
+                        Some(value) => value.to_string(),
+                    },
+                    StructElementType::Sint32(default) => match default {
+                        None => el.name.to_snake_case(),
+                        Some(value) => value.to_string(),
+                    },
+                    StructElementType::Uint64(default) => match default {
+                        None => el.name.to_snake_case(),
+                        Some(value) => value.to_string(),
+                    },
+                    StructElementType::Sint64(default) => match default {
+                        None => el.name.to_snake_case(),
+                        Some(value) => value.to_string(),
+                    },
+                    StructElementType::Float(default) => match default {
+                        None => el.name.to_snake_case(),
+                        Some(value) => format!("{:.}f", value),
+                    },
+                    StructElementType::Double(default) => match default {
+                        None => el.name.to_snake_case(),
+                        Some(value) => format!("{:.}", value),
+                    },
+                    StructElementType::String(default) => match default {
+                        None => el.name.to_snake_case(),
+                        Some(value) => format!("\"{}\"", value),
+                    },
+                    StructElementType::Struct(handle) => {
+                        if handle.is_default_constructed() {
+                            format!("{}_init()", handle.name().to_snake_case())
+                        } else {
+                            el.name.to_snake_case()
+                        }
+                    }
+                    StructElementType::StructRef(_) => el.name.to_snake_case(),
+                    StructElementType::Enum(handle, default) => match default {
+                        None => el.name.to_snake_case(),
+                        Some(value) => match handle.find_variant_by_name(value) {
+                            Some(variant) => format!(
+                                "{}_{}",
+                                handle.name.to_camel_case(),
+                                variant.name.to_camel_case()
+                            ),
+                            None => panic!("Variant {} not found in {}", value, handle.name),
+                        },
+                    },
+                    StructElementType::ClassRef(_) => el.name.to_snake_case(),
+                    StructElementType::Interface(_) => el.name.to_snake_case(),
+                    StructElementType::OneTimeCallback(_) => el.name.to_snake_case(),
+                    StructElementType::Iterator(_) => el.name.to_snake_case(),
+                    StructElementType::Collection(_) => el.name.to_snake_case(),
+                    StructElementType::Duration(mapping, default) => match default {
+                        None => el.name.to_snake_case(),
+                        Some(value) => match mapping {
+                            DurationMapping::Milliseconds => value.as_millis().to_string(),
+                            DurationMapping::Seconds => value.as_secs().to_string(),
+                            DurationMapping::SecondsFloat => value.as_secs_f32().to_string(),
+                        },
+                    },
+                };
+                f.writeln(&format!(".{} = {},", el.name.to_snake_case(), value))?;
+            }
+            Ok(())
+        })?;
+        f.writeln("};")
+    })?;
+
+    Ok(())
 }
 
 fn write_enum_definition(
@@ -303,7 +457,7 @@ fn write_enum_definition(
 ) -> FormattingResult<()> {
     doxygen(f, |f| doxygen_print(f, &handle.doc, lib))?;
 
-    f.writeln(&format!("typedef enum {}", handle.to_type()))?;
+    f.writeln(&format!("typedef enum {}", handle.to_c_type()))?;
     f.writeln("{")?;
     indented(f, |f| {
         for variant in &handle.variants {
@@ -317,19 +471,18 @@ fn write_enum_definition(
         }
         Ok(())
     })?;
-    f.writeln(&format!("}} {};", handle.to_type()))?;
+    f.writeln(&format!("}} {};", handle.to_c_type()))?;
 
     f.newline()?;
 
     f.writeln(&format!(
         "static const char* {}_to_string({} value)",
         handle.name,
-        handle.to_type()
+        handle.to_c_type()
     ))?;
     blocked(f, |f| {
         f.writeln("switch (value)")?;
-        f.writeln("{")?;
-        indented(f, |f| {
+        blocked(f, |f| {
             for variant in &handle.variants {
                 f.writeln(&format!(
                     "case {}_{}: return \"{}\";",
@@ -339,8 +492,7 @@ fn write_enum_definition(
                 ))?;
             }
             f.writeln("default: return \"\";")
-        })?;
-        f.writeln("}")
+        })
     })
 }
 
@@ -379,8 +531,8 @@ fn write_class_declaration(
 
     f.writeln(&format!(
         "typedef struct {} {};",
-        handle.to_type(),
-        handle.to_type()
+        handle.to_c_type(),
+        handle.to_c_type()
     ))
 }
 
@@ -437,7 +589,7 @@ fn write_function(
 fn write_interface(f: &mut dyn Printer, handle: &Interface, lib: &Library) -> FormattingResult<()> {
     doxygen(f, |f| doxygen_print(f, &handle.doc, lib))?;
 
-    f.writeln(&format!("typedef struct {}", handle.to_type()))?;
+    f.writeln(&format!("typedef struct {}", handle.to_c_type()))?;
     f.writeln("{")?;
     indented(f, |f| {
         for element in &handle.elements {
@@ -513,7 +665,7 @@ fn write_interface(f: &mut dyn Printer, handle: &Interface, lib: &Library) -> Fo
         }
         Ok(())
     })?;
-    f.writeln(&format!("}} {};", handle.to_type()))
+    f.writeln(&format!("}} {};", handle.to_c_type()))
 }
 
 fn write_one_time_callback(
@@ -523,7 +675,7 @@ fn write_one_time_callback(
 ) -> FormattingResult<()> {
     doxygen(f, |f| doxygen_print(f, &handle.doc, lib))?;
 
-    f.writeln(&format!("typedef struct {}", handle.to_type()))?;
+    f.writeln(&format!("typedef struct {}", handle.to_c_type()))?;
     f.writeln("{")?;
     indented(f, |f| {
         for element in &handle.elements {
@@ -592,7 +744,7 @@ fn write_one_time_callback(
         }
         Ok(())
     })?;
-    f.writeln(&format!("}} {};", handle.to_type()))
+    f.writeln(&format!("}} {};", handle.to_c_type()))
 }
 
 fn generate_cmake_config(lib: &Library, config: &CBindgenConfig) -> FormattingResult<()> {
@@ -678,14 +830,14 @@ impl<'a> Display for CType<'a> {
             Type::Float => write!(f, "float"),
             Type::Double => write!(f, "double"),
             Type::String => write!(f, "const char*"),
-            Type::Struct(handle) => write!(f, "{}", handle.to_type()),
-            Type::StructRef(handle) => write!(f, "{}*", handle.to_type()),
-            Type::Enum(handle) => write!(f, "{}", handle.to_type()),
-            Type::ClassRef(handle) => write!(f, "{}*", handle.to_type()),
-            Type::Interface(handle) => write!(f, "{}", handle.to_type()),
-            Type::OneTimeCallback(handle) => write!(f, "{}", handle.to_type()),
-            Type::Iterator(handle) => write!(f, "{}*", handle.iter_type.to_type()),
-            Type::Collection(handle) => write!(f, "{}*", handle.collection_type.to_type()),
+            Type::Struct(handle) => write!(f, "{}", handle.to_c_type()),
+            Type::StructRef(handle) => write!(f, "{}*", handle.to_c_type()),
+            Type::Enum(handle) => write!(f, "{}", handle.to_c_type()),
+            Type::ClassRef(handle) => write!(f, "{}*", handle.to_c_type()),
+            Type::Interface(handle) => write!(f, "{}", handle.to_c_type()),
+            Type::OneTimeCallback(handle) => write!(f, "{}", handle.to_c_type()),
+            Type::Iterator(handle) => write!(f, "{}*", handle.iter_type.to_c_type()),
+            Type::Collection(handle) => write!(f, "{}*", handle.collection_type.to_c_type()),
             Type::Duration(mapping) => match mapping {
                 DurationMapping::Milliseconds | DurationMapping::Seconds => write!(f, "uint64_t"),
                 DurationMapping::SecondsFloat => write!(f, "float"),

--- a/generators/c-oo-bindgen/src/lib.rs
+++ b/generators/c-oo-bindgen/src/lib.rs
@@ -287,7 +287,7 @@ fn write_struct_definition(
             })?;
             f.writeln(&format!(
                 "{} {};",
-                CType(&element.element_type),
+                CType(&element.element_type.to_type()),
                 element.name.to_snake_case(),
             ))?;
         }

--- a/generators/dotnet-oo-bindgen/src/callback.rs
+++ b/generators/dotnet-oo-bindgen/src/callback.rs
@@ -56,15 +56,13 @@ pub(crate) fn generate(
                 ))?;
                 f.write(
                     &func
-                        .parameters
-                        .iter()
-                        .filter_map(|param| match param {
-                            CallbackParameter::Parameter(param) => Some(format!(
+                        .params()
+                        .map(|param| {
+                            format!(
                                 "{} {}",
                                 param.param_type.as_dotnet_type(),
                                 param.name.to_mixed_case()
-                            )),
-                            _ => None,
+                            )
                         })
                         .collect::<Vec<String>>()
                         .join(", "),
@@ -74,6 +72,17 @@ pub(crate) fn generate(
         })?;
 
         f.newline()?;
+
+        // Write the Action<>/Func<> based implementation if it's a functional interface
+        if cb.is_functional() {
+            generate_functional_callback(
+                f,
+                &cb_name,
+                &cb.name.to_camel_case(),
+                cb.callbacks().next().unwrap(),
+            )?;
+            f.newline()?;
+        }
 
         // Create the native adapter
         f.writeln("[StructLayout(LayoutKind.Sequential)]")?;

--- a/generators/dotnet-oo-bindgen/src/conversion.rs
+++ b/generators/dotnet-oo-bindgen/src/conversion.rs
@@ -33,7 +33,7 @@ impl DotnetType for Type {
             Type::Double => "double".to_string(),
             Type::String => "string".to_string(),
             Type::Struct(handle) => handle.name().to_camel_case(),
-            Type::StructRef(handle) =>  handle.name.to_camel_case(),
+            Type::StructRef(handle) => handle.name.to_camel_case(),
             Type::Enum(handle) => handle.name.to_camel_case(),
             Type::ClassRef(handle) => handle.name.to_camel_case(),
             Type::Interface(handle) => format!("I{}", handle.name.to_camel_case()),
@@ -740,4 +740,83 @@ pub(crate) fn call_dotnet_function(
     }
 
     Ok(())
+}
+
+pub(crate) fn generate_functional_callback(
+    f: &mut dyn Printer,
+    interface_name: &str,
+    class_name: &str,
+    function: &CallbackFunction,
+) -> FormattingResult<()> {
+    // Build the Action<>/Func<> signature
+    let param_types = function
+        .params()
+        .map(|param| param.param_type.as_dotnet_type())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let action_type = match &function.return_type {
+        ReturnType::Type(return_type, _) => {
+            if param_types.is_empty() {
+                format!("Func<{}>", return_type.as_dotnet_type())
+            } else {
+                format!("Func<{}, {}>", param_types, return_type.as_dotnet_type())
+            }
+        }
+        ReturnType::Void => {
+            if param_types.is_empty() {
+                "Action".to_string()
+            } else {
+                format!("Action<{}>", param_types)
+            }
+        }
+    };
+
+    f.writeln(&format!("public class {} : {}", class_name, interface_name))?;
+    blocked(f, |f| {
+        f.writeln(&format!("readonly {} action;", action_type))?;
+
+        f.newline()?;
+
+        // Write the constructor
+        f.writeln(&format!("public {}({} action)", class_name, action_type))?;
+        blocked(f, |f| f.writeln("this.action = action;"))?;
+
+        f.newline()?;
+
+        // Write the required method
+        f.writeln(&format!(
+            "public {} {}(",
+            function.return_type.as_dotnet_type(),
+            function.name.to_camel_case()
+        ))?;
+        f.write(
+            &function
+                .params()
+                .map(|param| {
+                    format!(
+                        "{} {}",
+                        param.param_type.as_dotnet_type(),
+                        param.name.to_mixed_case()
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", "),
+        )?;
+        f.write(")")?;
+        blocked(f, |f| {
+            f.newline()?;
+
+            if !function.return_type.is_void() {
+                f.write("return ")?;
+            }
+
+            let params = function
+                .params()
+                .map(|param| param.name.to_mixed_case())
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            f.write(&format!("this.action.Invoke({});", params))
+        })
+    })
 }

--- a/generators/dotnet-oo-bindgen/src/conversion.rs
+++ b/generators/dotnet-oo-bindgen/src/conversion.rs
@@ -33,7 +33,7 @@ impl DotnetType for Type {
             Type::Double => "double".to_string(),
             Type::String => "string".to_string(),
             Type::Struct(handle) => handle.name().to_camel_case(),
-            Type::StructRef(handle) => format!("{}", handle.name.to_camel_case()),
+            Type::StructRef(handle) =>  handle.name.to_camel_case(),
             Type::Enum(handle) => handle.name.to_camel_case(),
             Type::ClassRef(handle) => handle.name.to_camel_case(),
             Type::Interface(handle) => format!("I{}", handle.name.to_camel_case()),

--- a/generators/dotnet-oo-bindgen/src/conversion.rs
+++ b/generators/dotnet-oo-bindgen/src/conversion.rs
@@ -33,7 +33,7 @@ impl DotnetType for Type {
             Type::Double => "double".to_string(),
             Type::String => "string".to_string(),
             Type::Struct(handle) => handle.name().to_camel_case(),
-            Type::StructRef(handle) => format!("{}?", handle.name.to_camel_case()),
+            Type::StructRef(handle) => format!("{}", handle.name.to_camel_case()),
             Type::Enum(handle) => handle.name.to_camel_case(),
             Type::ClassRef(handle) => handle.name.to_camel_case(),
             Type::Interface(handle) => format!("I{}", handle.name.to_camel_case()),
@@ -377,7 +377,7 @@ impl TypeConverter for StructRefConverter {
     ) -> FormattingResult<()> {
         let handle_name = format!("_{}Handle", from.replace(".", "_"));
         f.writeln(&format!(
-            "{}? {} = null;",
+            "{} {} = null;",
             self.0.name.to_camel_case(),
             handle_name
         ))?;
@@ -466,7 +466,7 @@ impl TypeConverter for IteratorConverter {
         ))?;
         blocked(f, |f| {
             f.writeln(&format!(
-                "{}? _itValue = null;",
+                "{} _itValue = null;",
                 self.0.item_type.name().to_camel_case()
             ))?;
             StructRefConverter(self.0.item_type.declaration()).convert_from_native(
@@ -474,7 +474,7 @@ impl TypeConverter for IteratorConverter {
                 "_itRawValue",
                 "_itValue = ",
             )?;
-            f.writeln(&format!("{}.Add(_itValue.Value);", builder_name))
+            f.writeln(&format!("{}.Add(_itValue);", builder_name))
         })?;
         f.writeln(&format!("{}{}.ToImmutable();", to, builder_name))
     }

--- a/generators/dotnet-oo-bindgen/src/interface.rs
+++ b/generators/dotnet-oo-bindgen/src/interface.rs
@@ -62,15 +62,13 @@ pub(crate) fn generate(
                     ))?;
                     f.write(
                         &func
-                            .parameters
-                            .iter()
-                            .filter_map(|param| match param {
-                                CallbackParameter::Parameter(param) => Some(format!(
+                            .params()
+                            .map(|param| {
+                                format!(
                                     "{} {}",
                                     param.param_type.as_dotnet_type(),
                                     param.name.to_mixed_case()
-                                )),
-                                _ => None,
+                                )
                             })
                             .collect::<Vec<String>>()
                             .join(", "),
@@ -80,6 +78,17 @@ pub(crate) fn generate(
         })?;
 
         f.newline()?;
+
+        // Write the Action<>/Func<> based implementation if it's a functional interface
+        if interface.is_functional() {
+            generate_functional_callback(
+                f,
+                &interface_name,
+                &interface.name.to_camel_case(),
+                interface.callbacks().next().unwrap(),
+            )?;
+            f.newline()?;
+        }
 
         // Create the native adapter
         f.writeln("[StructLayout(LayoutKind.Sequential)]")?;

--- a/generators/dotnet-oo-bindgen/src/structure.rs
+++ b/generators/dotnet-oo-bindgen/src/structure.rs
@@ -26,7 +26,48 @@ pub(crate) fn generate(
             for el in native_struct.elements() {
                 documentation(f, |f| {
                     // Print top-level documentation
-                    xmldoc_print(f, &el.doc, lib)
+                    xmldoc_print(f, &el.doc, lib)?;
+
+                    let default_value = match &el.element_type {
+                        StructElementType::Bool(default) => default.map(|x| x.to_string()),
+                        StructElementType::Uint8(default) => default.map(|x| x.to_string()),
+                        StructElementType::Sint8(default) => default.map(|x| x.to_string()),
+                        StructElementType::Uint16(default) => default.map(|x| x.to_string()),
+                        StructElementType::Sint16(default) => default.map(|x| x.to_string()),
+                        StructElementType::Uint32(default) => default.map(|x| x.to_string()),
+                        StructElementType::Sint32(default) => default.map(|x| x.to_string()),
+                        StructElementType::Uint64(default) => default.map(|x| x.to_string()),
+                        StructElementType::Sint64(default) => default.map(|x| x.to_string()),
+                        StructElementType::Float(default) => default.map(|x| x.to_string()),
+                        StructElementType::Double(default) => default.map(|x| x.to_string()),
+                        StructElementType::String(default) => default.clone(),
+                        StructElementType::Struct(_) => None,
+                        StructElementType::StructRef(_) => None,
+                        StructElementType::Enum(handle, default) => default.clone().map(|x| {
+                            format!(
+                                "<see cref=\"{}.{}\" />",
+                                handle.name.to_camel_case(),
+                                x.to_camel_case()
+                            )
+                        }),
+                        StructElementType::ClassRef(_) => None,
+                        StructElementType::Interface(_) => None,
+                        StructElementType::OneTimeCallback(_) => None,
+                        StructElementType::Iterator(_) => None,
+                        StructElementType::Collection(_) => None,
+                        StructElementType::Duration(_, default) => {
+                            default.map(|x| format!("{}s", x.as_secs_f32()))
+                        }
+                    };
+
+                    if let Some(default_value) = default_value {
+                        f.writeln(&format!(
+                            "<value>Default value is {}</value>",
+                            default_value
+                        ))?;
+                    }
+
+                    Ok(())
                 })?;
 
                 f.writeln(&format!(
@@ -103,7 +144,7 @@ pub(crate) fn generate(
                     StructElementType::StructRef(_) => (),
                     StructElementType::Enum(handle, default) => {
                         if let Some(value) = default {
-                            match handle.find_variant_by_value(*value) {
+                            match handle.find_variant_by_name(value) {
                                 Some(variant) => f.write(&format!(
                                     " = {}.{}",
                                     handle.name.to_camel_case(),

--- a/generators/dotnet-oo-bindgen/src/structure.rs
+++ b/generators/dotnet-oo-bindgen/src/structure.rs
@@ -40,7 +40,9 @@ pub(crate) fn generate(
                         StructElementType::Sint64(default) => default.map(|x| x.to_string()),
                         StructElementType::Float(default) => default.map(|x| x.to_string()),
                         StructElementType::Double(default) => default.map(|x| x.to_string()),
-                        StructElementType::String(default) => default.clone(),
+                        StructElementType::String(default) => {
+                            default.clone().map(|x| format!("\"{}\"", x))
+                        }
                         StructElementType::Struct(_) => None,
                         StructElementType::StructRef(_) => None,
                         StructElementType::Enum(handle, default) => default.clone().map(|x| {
@@ -186,7 +188,7 @@ pub(crate) fn generate(
 
             // Write constructor
             if !native_struct.definition().is_default_constructed() {
-                f.writeln(&format!("public {}(", struct_name,))?;
+                f.writeln(&format!("public {}(", struct_name))?;
                 f.write(
                     &native_struct
                         .elements()

--- a/generators/java-oo-bindgen/src/java/callback.rs
+++ b/generators/java-oo-bindgen/src/java/callback.rs
@@ -10,6 +10,9 @@ pub(crate) fn generate(
 ) -> FormattingResult<()> {
     let callback_name = callback.name.to_camel_case();
 
+    if callback.is_functional() {
+        f.writeln("@FunctionalInterface")?;
+    }
     f.writeln(&format!("public interface {}", callback_name))?;
     blocked(f, |f| {
         // Write each required method

--- a/generators/java-oo-bindgen/src/java/interface.rs
+++ b/generators/java-oo-bindgen/src/java/interface.rs
@@ -15,6 +15,9 @@ pub(crate) fn generate(
         javadoc_print(f, &interface.doc, lib)
     })?;
 
+    if interface.is_functional() {
+        f.writeln("@FunctionalInterface")?;
+    }
     f.writeln(&format!("public interface {}", interface_name))?;
     blocked(f, |f| {
         // Write each required method

--- a/generators/java-oo-bindgen/src/java/structure.rs
+++ b/generators/java-oo-bindgen/src/java/structure.rs
@@ -93,22 +93,22 @@ pub(crate) fn generate(
                 }
                 StructElementType::Uint32(default) => {
                     if let Some(value) = default {
-                        f.write(&format!(" = UInteger.valueOf({})", value))?;
+                        f.write(&format!(" = UInteger.valueOf({}L)", value))?;
                     }
                 }
                 StructElementType::Sint32(default) => {
                     if let Some(value) = default {
-                        f.write(&format!(" = (int){}", value))?;
+                        f.write(&format!(" = {}", value))?;
                     }
                 }
                 StructElementType::Uint64(default) => {
                     if let Some(value) = default {
-                        f.write(&format!(" = ULong.valueOf({})", value))?;
+                        f.write(&format!(" = ULong.valueOf({}L)", value))?;
                     }
                 }
                 StructElementType::Sint64(default) => {
                     if let Some(value) = default {
-                        f.write(&format!(" = (long){}", value))?;
+                        f.write(&format!(" = {}L", value))?;
                     }
                 }
                 StructElementType::Float(default) => {

--- a/generators/java-oo-bindgen/src/java/structure.rs
+++ b/generators/java-oo-bindgen/src/java/structure.rs
@@ -33,7 +33,9 @@ pub(crate) fn generate(
                     StructElementType::Sint64(default) => default.map(|x| x.to_string()),
                     StructElementType::Float(default) => default.map(|x| x.to_string()),
                     StructElementType::Double(default) => default.map(|x| x.to_string()),
-                    StructElementType::String(default) => default.clone(),
+                    StructElementType::String(default) => {
+                        default.clone().map(|x| format!("\"{}\"", x))
+                    }
                     StructElementType::Struct(_) => None,
                     StructElementType::StructRef(_) => None,
                     StructElementType::Enum(handle, default) => default.clone().map(|x| {

--- a/generators/rust-oo-bindgen/src/conversion.rs
+++ b/generators/rust-oo-bindgen/src/conversion.rs
@@ -340,7 +340,7 @@ impl RustStruct for NativeStructHandle {
     fn has_conversion(&self) -> bool {
         self.elements
             .iter()
-            .any(|e| e.element_type.has_conversion())
+            .any(|e| e.element_type.to_type().has_conversion())
     }
 }
 
@@ -351,11 +351,11 @@ pub(crate) trait RustStructField {
 
 impl RustStructField for NativeStructElement {
     fn rust_requires_lifetime(&self) -> bool {
-        self.element_type.rust_requires_lifetime()
+        self.element_type.to_type().rust_requires_lifetime()
     }
 
     fn c_requires_lifetime(&self) -> bool {
-        self.element_type.c_requires_lifetime()
+        self.element_type.to_type().c_requires_lifetime()
     }
 }
 

--- a/generators/rust-oo-bindgen/src/lib.rs
+++ b/generators/rust-oo-bindgen/src/lib.rs
@@ -125,7 +125,7 @@ impl<'a> RustCodegen<'a> {
                     "{}{}: {},",
                     public,
                     element.name,
-                    element.element_type.as_c_type()
+                    element.element_type.to_type().as_c_type()
                 ))?;
             }
             Ok(())
@@ -152,7 +152,7 @@ impl<'a> RustCodegen<'a> {
                     } else {
                         ""
                     };
-                let ampersand = if element.element_type.is_copyable() {
+                let ampersand = if element.element_type.to_type().is_copyable() {
                     ""
                 } else {
                     "&"
@@ -163,13 +163,13 @@ impl<'a> RustCodegen<'a> {
                 f.writeln(&format!(
                     "pub fn {name}{fn_lifetime}(&{lifetime}self) -> {ampersand}{return_type}",
                     name = element.name,
-                    return_type = element.element_type.as_rust_type(),
+                    return_type = element.element_type.to_type().as_rust_type(),
                     fn_lifetime = fn_lifetime,
                     lifetime = el_lifetime,
                     ampersand = ampersand
                 ))?;
                 blocked(f, |f| {
-                    if let Some(conversion) = element.element_type.conversion() {
+                    if let Some(conversion) = element.element_type.to_type().conversion() {
                         if conversion.is_unsafe() {
                             f.writeln("unsafe {")?;
                         }
@@ -202,12 +202,12 @@ impl<'a> RustCodegen<'a> {
                 f.writeln(&format!(
                     "pub fn set_{name}{fn_lifetime}(&{lifetime}mut self, value: {element_type})",
                     name = element.name,
-                    element_type = element.element_type.as_rust_type(),
+                    element_type = element.element_type.to_type().as_rust_type(),
                     fn_lifetime = fn_lifetime,
                     lifetime = el_lifetime
                 ))?;
                 blocked(f, |f| {
-                    if let Some(conversion) = element.element_type.conversion() {
+                    if let Some(conversion) = element.element_type.to_type().conversion() {
                         conversion.convert_to_c(
                             f,
                             "value",
@@ -233,7 +233,7 @@ impl<'a> RustCodegen<'a> {
                     f.writeln(&format!(
                         "pub {}: {},",
                         element.name,
-                        element.element_type.as_rust_type()
+                        element.element_type.to_type().as_rust_type()
                     ))?;
                 }
                 Ok(())
@@ -253,7 +253,7 @@ impl<'a> RustCodegen<'a> {
                     f.writeln("Self")?;
                     blocked(f, |f| {
                         for element in &handle.elements {
-                            if let Some(conversion) = element.element_type.conversion() {
+                            if let Some(conversion) = element.element_type.to_type().conversion() {
                                 conversion.convert_to_c(
                                     f,
                                     &format!("from.{}", element.name),

--- a/oo-bindgen/src/callback.rs
+++ b/oo-bindgen/src/callback.rs
@@ -56,6 +56,10 @@ impl Interface {
         self.callbacks()
             .find(|callback| callback.name == name.as_ref())
     }
+
+    pub fn is_functional(&self) -> bool {
+        self.callbacks().count() == 1
+    }
 }
 
 pub type InterfaceHandle = Handle<Interface>;
@@ -190,6 +194,10 @@ impl OneTimeCallback {
     pub fn find_callback<T: AsRef<str>>(&self, name: T) -> Option<&CallbackFunction> {
         self.callbacks()
             .find(|callback| callback.name == name.as_ref())
+    }
+
+    pub fn is_functional(&self) -> bool {
+        self.callbacks().count() == 1
     }
 }
 

--- a/oo-bindgen/src/doc.rs
+++ b/oo-bindgen/src/doc.rs
@@ -580,7 +580,7 @@ fn validate_reference_with_params(
         }
         DocReference::EnumVariant(enum_name, variant_name) => {
             if let Some(handle) = lib.find_enum(enum_name) {
-                if handle.find_variant(variant_name).is_none() {
+                if handle.find_variant_by_name(variant_name).is_none() {
                     return Err(BindingError::DocInvalidReference {
                         symbol_name: symbol_name.to_string(),
                         ref_name: format!("{}.{}", enum_name.to_string(), variant_name.to_string()),

--- a/oo-bindgen/src/lib.rs
+++ b/oo-bindgen/src/lib.rs
@@ -133,6 +133,12 @@ pub enum BindingError {
         variant_value
     )]
     NativeEnumAlreadyContainsVariantWithSameValue { name: String, variant_value: i32 },
+    #[error(
+        "Native enum '{}' does not contain a variant named '{}'",
+        name,
+        variant_name
+    )]
+    NativeEnumDoesNotContainVariant { name: String, variant_name: String },
 
     // Structure errors
     #[error("Native struct '{}' was already defined", handle.name)]

--- a/oo-bindgen/src/native_enum.rs
+++ b/oo-bindgen/src/native_enum.rs
@@ -16,10 +16,14 @@ pub struct NativeEnum {
 }
 
 impl NativeEnum {
-    pub fn find_variant<T: AsRef<str>>(&self, variant_name: T) -> Option<&EnumVariant> {
+    pub fn find_variant_by_name<T: AsRef<str>>(&self, variant_name: T) -> Option<&EnumVariant> {
         self.variants
             .iter()
             .find(|variant| variant.name == variant_name.as_ref())
+    }
+
+    pub fn find_variant_by_value(&self, value: i32) -> Option<&EnumVariant> {
+        self.variants.iter().find(|variant| variant.value == value)
     }
 }
 

--- a/oo-bindgen/src/native_struct.rs
+++ b/oo-bindgen/src/native_struct.rs
@@ -67,7 +67,7 @@ impl StructElementType {
             Self::OneTimeCallback(handle) => Type::OneTimeCallback(handle.clone()),
             Self::Iterator(handle) => Type::Iterator(handle.clone()),
             Self::Collection(handle) => Type::Collection(handle.clone()),
-            Self::Duration(mapping, _) => Type::Duration(mapping.clone()),
+            Self::Duration(mapping, _) => Type::Duration(*mapping),
         }
     }
 
@@ -129,15 +129,15 @@ impl From<Type> for StructElementType {
             Type::Float => Self::Float(None),
             Type::Double => Self::Double(None),
             Type::String => Self::String(None),
-            Type::Struct(handle) => Self::Struct(handle.clone()),
-            Type::StructRef(handle) => Self::StructRef(handle.clone()),
-            Type::Enum(handle) => Self::Enum(handle.clone(), None),
-            Type::ClassRef(handle) => Self::ClassRef(handle.clone()),
-            Type::Interface(handle) => Self::Interface(handle.clone()),
-            Type::OneTimeCallback(handle) => Self::OneTimeCallback(handle.clone()),
-            Type::Iterator(handle) => Self::Iterator(handle.clone()),
-            Type::Collection(handle) => Self::Collection(handle.clone()),
-            Type::Duration(mapping) => Self::Duration(mapping.clone(), None),
+            Type::Struct(handle) => Self::Struct(handle),
+            Type::StructRef(handle) => Self::StructRef(handle),
+            Type::Enum(handle) => Self::Enum(handle, None),
+            Type::ClassRef(handle) => Self::ClassRef(handle),
+            Type::Interface(handle) => Self::Interface(handle),
+            Type::OneTimeCallback(handle) => Self::OneTimeCallback(handle),
+            Type::Iterator(handle) => Self::Iterator(handle),
+            Type::Collection(handle) => Self::Collection(handle),
+            Type::Duration(mapping) => Self::Duration(mapping, None),
         }
     }
 }
@@ -168,6 +168,10 @@ impl NativeStruct {
 
     pub fn is_default_constructed(&self) -> bool {
         self.elements.iter().all(|el| el.element_type.has_default())
+    }
+
+    pub fn elements(&self) -> impl Iterator<Item = &NativeStructElement> {
+        self.elements.iter()
     }
 }
 
@@ -292,7 +296,7 @@ impl Struct {
     }
 
     pub fn elements(&self) -> impl Iterator<Item = &NativeStructElement> {
-        self.definition.elements.iter()
+        self.definition.elements()
     }
 
     pub fn doc(&self) -> &Doc {

--- a/tests/bindings/c/structure_tests.c
+++ b/tests/bindings/c/structure_tests.c
@@ -74,8 +74,17 @@ static void test_struct_by_reference()
     check_struct(&result);
 }
 
+static void test_struct_init()
+{
+    structure_t test = structure_init((structure_interface_t) {NULL, NULL, NULL});
+    assert(strcmp("Hello", test.string_value) == 0);
+    test.string_value = ENGLISH_STRING_1;
+    check_struct(&test);
+}
+
 void structure_tests()
 {
     test_struct_by_value();
     test_struct_by_reference();
+    test_struct_init();
 }

--- a/tests/bindings/dotnet/foo.Tests/StructureTest.cs
+++ b/tests/bindings/dotnet/foo.Tests/StructureTest.cs
@@ -6,9 +6,9 @@ namespace foo.Tests
 {
     class TestInterface : IStructureInterface
     {
-        public Structure? lastValue = null;
+        public Structure lastValue = null;
 
-        public void OnValue(Structure? value)
+        public void OnValue(Structure value)
         {
             this.lastValue = value;
         }
@@ -21,7 +21,7 @@ namespace foo.Tests
         {
             var value = CreateStructure();
             var result = Structure.StructByValueEcho(value);
-            CheckStructure(ref result);
+            CheckStructure(result);
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace foo.Tests
         {
             var value = CreateStructure();
             var result = value.StructByReferenceEcho();
-            CheckStructure(ref result);
+            CheckStructure(result);
         }
 
         [Fact]
@@ -42,8 +42,7 @@ namespace foo.Tests
             Structure.StructByValueEcho(value);
 
             Assert.NotNull(testInterface.lastValue);
-            var lastValue = testInterface.lastValue.Value;
-            CheckStructure(ref lastValue);
+            CheckStructure(testInterface.lastValue);
         }
 
         [Fact]
@@ -59,35 +58,12 @@ namespace foo.Tests
 
         private Structure CreateStructure()
         {
-            var structure = new Structure();
-
-            structure.BooleanValue = true;
-            structure.Uint8Value = 1;
-            structure.Int8Value = -1;
-            structure.Uint16Value = 2;
-            structure.Int16Value = -2;
-            structure.Uint32Value = 3;
-            structure.Int32Value = -3;
-            structure.Uint64Value = 4;
-            structure.Int64Value = -4;
-            structure.FloatValue = 12.34f;
-            structure.DoubleValue = -56.78;
-            structure.StringValue = "Hello from C#!";
-
-            structure.StructureValue.Test = 41;
-
-            structure.EnumValue = StructureEnum.Var2;
-
-            structure.InterfaceValue = new TestInterface();
-
-            structure.DurationMillis = TimeSpan.FromMilliseconds(4200);
-            structure.DurationSeconds = TimeSpan.FromSeconds(76);
-            structure.DurationSecondsFloat = TimeSpan.FromSeconds(15.25f);
+            var structure = new Structure(new TestInterface());
 
             return structure;
         }
 
-        private void CheckStructure(ref Structure structure)
+        private void CheckStructure(Structure structure)
         {
             Assert.True(structure.BooleanValue);
             Assert.Equal(1u, structure.Uint8Value);

--- a/tests/bindings/java/foo-tests/src/test/java/io/stepfunc/foo_test/StructureTest.java
+++ b/tests/bindings/java/foo-tests/src/test/java/io/stepfunc/foo_test/StructureTest.java
@@ -48,33 +48,7 @@ public class StructureTest {
     }
 
     public static Structure createStructure() {
-        Structure structure = new Structure();
-
-        structure.booleanValue = true;
-        structure.uint8Value = ubyte(1);
-        structure.int8Value = -1;
-        structure.uint16Value = ushort(2);
-        structure.int16Value = -2;
-        structure.uint32Value = uint(3);
-        structure.int32Value = -3;
-        structure.uint64Value = ulong(4L);
-        structure.int64Value = -4L;
-        structure.floatValue = 12.34f;
-        structure.doubleValue = -56.78;
-        structure.stringValue = "asdf";
-
-        structure.structureValue = new OtherStructure();
-        structure.structureValue.test = ushort(41);
-
-        structure.enumValue = StructureEnum.VAR2;
-
-        structure.interfaceValue = new TestInterface();
-
-        structure.durationMillis = Duration.ofMillis(4200);
-        structure.durationSeconds = Duration.ofSeconds(76);
-        structure.durationSecondsFloat = Duration.ofSeconds(15).plusMillis(250);
-
-        return structure;
+        return new Structure(new TestInterface());
     }
 
     private static void checkStructure(Structure structure) {
@@ -89,7 +63,7 @@ public class StructureTest {
         assertThat(structure.int64Value).isEqualTo(-4);
         assertThat(structure.floatValue).isEqualTo(12.34f);
         assertThat(structure.doubleValue).isEqualTo(-56.78);
-        assertThat(structure.stringValue).isEqualTo("asdf");
+        assertThat(structure.stringValue).isEqualTo("Hello");
 
         assertThat(structure.structureValue.test).isEqualTo(ushort(41));
         assertThat(structure.enumValue).isEqualTo(StructureEnum.VAR2);

--- a/tests/foo-schema/src/structure.rs
+++ b/tests/foo-schema/src/structure.rs
@@ -1,11 +1,14 @@
+use std::time::Duration;
+
 use oo_bindgen::native_function::*;
+use oo_bindgen::native_struct::StructElementType;
 use oo_bindgen::*;
 
 pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
     let other_structure = lib.declare_native_struct("OtherStructure")?;
     let other_structure = lib
         .define_native_struct(&other_structure)?
-        .add("test", Type::Uint16, "test")?
+        .add("test", StructElementType::Uint16(Some(41)), "test")?
         .doc("Structure within a structure")?
         .build()?;
 
@@ -30,24 +33,76 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
 
     let structure = lib
         .define_native_struct(&structure)?
-        .add("boolean_value", Type::Bool, "boolean_value")?
-        .add("uint8_value", Type::Uint8, "uint8_value")?
-        .add("int8_value", Type::Sint8, "int8_value")?
-        .add("uint16_value", Type::Uint16, "uint16_value")?
-        .add("int16_value", Type::Sint16, "int16_value")?
-        .add("uint32_value", Type::Uint32, "uint32_value")?
-        .add("int32_value", Type::Sint32, "int32_value")?
-        .add("uint64_value", Type::Uint64, "uint64_value")?
-        .add("int64_value", Type::Sint64, "int64_value")?
-        .add("float_value", Type::Float, "float_value")?
-        .add("double_value", Type::Double, "double_value")?
-        .add("string_value", Type::String, "string_value")?
+        .add(
+            "boolean_value",
+            StructElementType::Bool(Some(true)),
+            "boolean_value",
+        )?
+        .add(
+            "uint8_value",
+            StructElementType::Uint8(Some(1)),
+            "uint8_value",
+        )?
+        .add(
+            "int8_value",
+            StructElementType::Sint8(Some(-1)),
+            "int8_value",
+        )?
+        .add(
+            "uint16_value",
+            StructElementType::Uint16(Some(2)),
+            "uint16_value",
+        )?
+        .add(
+            "int16_value",
+            StructElementType::Sint16(Some(-2)),
+            "int16_value",
+        )?
+        .add(
+            "uint32_value",
+            StructElementType::Uint32(Some(3)),
+            "uint32_value",
+        )?
+        .add(
+            "int32_value",
+            StructElementType::Sint32(Some(-3)),
+            "int32_value",
+        )?
+        .add(
+            "uint64_value",
+            StructElementType::Uint64(Some(4)),
+            "uint64_value",
+        )?
+        .add(
+            "int64_value",
+            StructElementType::Sint64(Some(-4)),
+            "int64_value",
+        )?
+        .add(
+            "float_value",
+            StructElementType::Float(Some(12.34)),
+            "float_value",
+        )?
+        .add(
+            "double_value",
+            StructElementType::Double(Some(-56.78)),
+            "double_value",
+        )?
+        .add(
+            "string_value",
+            StructElementType::String(Some("Hello".to_string())),
+            "string_value",
+        )?
         .add(
             "structure_value",
             Type::Struct(other_structure),
             "structure_value",
         )?
-        .add("enum_value", Type::Enum(structure_enum), "enum_value")?
+        .add(
+            "enum_value",
+            StructElementType::Enum(structure_enum, Some(1)),
+            "enum_value",
+        )?
         .add(
             "interface_value",
             Type::Interface(structure_interface),
@@ -55,17 +110,23 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
         )?
         .add(
             "duration_millis",
-            Type::Duration(DurationMapping::Milliseconds),
+            StructElementType::Duration(
+                DurationMapping::Milliseconds,
+                Some(Duration::from_millis(4200)),
+            ),
             "duration_millis",
         )?
         .add(
             "duration_seconds",
-            Type::Duration(DurationMapping::Seconds),
+            StructElementType::Duration(DurationMapping::Seconds, Some(Duration::from_secs(76))),
             "duration_seconds",
         )?
         .add(
             "duration_seconds_float",
-            Type::Duration(DurationMapping::SecondsFloat),
+            StructElementType::Duration(
+                DurationMapping::SecondsFloat,
+                Some(Duration::from_millis(15250)),
+            ),
             "duration_seconds_float",
         )?
         .doc("Test structure")?

--- a/tests/foo-schema/src/structure.rs
+++ b/tests/foo-schema/src/structure.rs
@@ -100,7 +100,7 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
         )?
         .add(
             "enum_value",
-            StructElementType::Enum(structure_enum, Some(1)),
+            StructElementType::Enum(structure_enum, Some("Var2".to_string())),
             "enum_value",
         )?
         .add(


### PR DESCRIPTION
- Fix #20 and fix #33.
  - It is now possible to define a default value to any struct field.
  - If all the fields of a struct have a default value, then it automatically has a default value if used within another struct
  - In C# and Java, structs now have a constructor that takes all the values that do not have a default value.
  - All documentation states the default value (if there is one)
  - In C, static (from a translation unit perspective) functions named `{struct_name}_init` are provided. They work the same way as the constructors in C# and Java.
- Fix #34
  - In C#, when an interface or a one-time callback is functional (it only contains a single callback), then a implementation of the interface is generated. Its constructor takes an `Action` or a `Func` which can be a lambda function.
  - In Java, the `FunctionalInterface` is added to these interfaces.