### PR TITLE
Add musl generator in the CI

### DIFF
--- a/.cargo/config-linux-musl.toml
+++ b/.cargo/config-linux-musl.toml
@@ -1,0 +1,3 @@
+[build]
+target = "x86_64-unknown-linux-musl"
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,24 +16,43 @@ jobs:
           - stable
           - beta
           - nightly
+        toolchain:
+          - default
+          - musl
+        exclude:
+          - os: windows-latest
+            toolchain: musl
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Install Rust ${{ matrix.rust }}
+        if: ${{ matrix.toolchain != 'musl' }}
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Install Rust ${{ matrix.rust }} (musl)
+        if: ${{ matrix.toolchain == 'musl' }}
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          target: x86_64-unknown-linux-musl
           override: true
       - name: Copy Windows config
         if: ${{ runner.os == 'Windows' }}
         shell: pwsh
         run: Copy-Item -Path .cargo/config-windows.toml -Destination .cargo/config.toml
       - name: Copy Linux config
-        if: ${{ runner.os == 'Linux' }}
+        if: ${{ runner.os == 'Linux' && matrix.toolchain == 'default' }}
         shell: pwsh
         run: Copy-Item -Path .cargo/config-linux.toml -Destination .cargo/config.toml
+      - name: Copy Linux musl config
+        if: ${{ runner.os == 'Linux' && matrix.toolchain == 'musl' }}
+        shell: pwsh
+        run: Copy-Item -Path .cargo/config-linux-musl.toml -Destination .cargo/config.toml
       - name: Run Rust unit tests
         uses: actions-rs/cargo@v1
         with:
@@ -44,11 +63,13 @@ jobs:
           command: run
           args: --release --bin foo-bindings -- --c
       - name: .NET bindings
+        if: ${{ matrix.toolchain != 'musl' }}
         uses: actions-rs/cargo@v1
         with:
           command: run
           args: --release --bin foo-bindings -- --dotnet
       - name: Java bindings
+        if: ${{ matrix.toolchain != 'musl' }}
         uses: actions-rs/cargo@v1
         with:
           command: run
@@ -60,7 +81,7 @@ jobs:
           name: ffi-modules
           path: tests/bindings/c/generated/lib
       - name: Upload compiled Java bindings
-        if: ${{ matrix.rust == 'stable' }}
+        if: ${{ matrix.rust == 'stable' && matrix.toolchain != 'musl' }}
         uses: actions/upload-artifact@v2
         with:
           name: ffi-modules

--- a/generators/c-oo-bindgen/src/lib.rs
+++ b/generators/c-oo-bindgen/src/lib.rs
@@ -46,7 +46,7 @@ clippy::all
 
 use crate::doc::*;
 use crate::formatting::*;
-use heck::{CamelCase, SnakeCase};
+use heck::{CamelCase, ShoutySnakeCase, SnakeCase};
 use oo_bindgen::callback::*;
 use oo_bindgen::class::*;
 use oo_bindgen::doc::*;
@@ -760,11 +760,44 @@ fn generate_cmake_config(lib: &Library, config: &CBindgenConfig) -> FormattingRe
 
     // Write each platform variation
     let mut is_first_if = true;
+
+    // Add a config value if we have two linux versions
+    let has_static_choice =
+        if config.platforms.linux.is_some() && config.platforms.linux_musl.is_some() {
+            f.writeln(&format!(
+            "set({}_STATIC_MUSL OFF CACHE BOOL \"Use statically built musl lib on Linux for {}\")",
+            lib.name.to_shouty_snake_case(),
+            lib.name
+        ))?;
+            f.newline()?;
+            true
+        } else {
+            false
+        };
+
     for p in config.platforms.iter() {
         let platform_check = match p.platform {
-            Platform::Win64 => "WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 8",
-            Platform::Win32 => "WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4",
-            Platform::Linux => "UNIX AND CMAKE_SIZEOF_VOID_P EQUAL 8",
+            Platform::Win64 => "WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 8".to_string(),
+            Platform::Linux => {
+                if !has_static_choice {
+                    "UNIX AND CMAKE_SIZEOF_VOID_P EQUAL 8".to_string()
+                } else {
+                    format!(
+                        "UNIX AND CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT $CACHE{{{}_STATIC_MUSL}}",
+                        lib.name.to_shouty_snake_case()
+                    )
+                }
+            }
+            Platform::LinuxMusl => {
+                if !has_static_choice {
+                    "UNIX AND CMAKE_SIZEOF_VOID_P EQUAL 8".to_string()
+                } else {
+                    format!(
+                        "UNIX AND CMAKE_SIZEOF_VOID_P EQUAL 8 AND $CACHE{{{}_STATIC_MUSL}}",
+                        lib.name.to_shouty_snake_case()
+                    )
+                }
+            }
         };
 
         if is_first_if {

--- a/generators/dotnet-oo-bindgen/src/lib.rs
+++ b/generators/dotnet-oo-bindgen/src/lib.rs
@@ -108,7 +108,11 @@ fn generate_csproj(lib: &Library, config: &DotnetBindgenConfig) -> FormattingRes
     f.newline()?;
     f.writeln("  <ItemGroup>")?;
 
-    for p in config.platforms.iter() {
+    for p in config
+        .platforms
+        .iter()
+        .filter(|x| x.platform != Platform::LinuxMusl)
+    {
         let filename = p.bin_filename(&config.ffi_name);
         let filepath = dunce::canonicalize(p.location.join(&filename))?;
         f.writeln(&format!("    <Content Include=\"{}\" Link=\"{}\" Pack=\"true\" PackagePath=\"runtimes/{}/native\" CopyToOutputDirectory=\"PreserveNewest\" />", filepath.to_string_lossy(), filename, p.platform.to_string()))?;

--- a/generators/java-oo-bindgen/src/java/mod.rs
+++ b/generators/java-oo-bindgen/src/java/mod.rs
@@ -28,7 +28,11 @@ pub fn generate_java_bindings(lib: &Library, config: &JavaBindgenConfig) -> Form
     // Copy the compiled libraries to the resource folder
     let mut ffi_name = config.ffi_name.clone();
     ffi_name.push_str("_java");
-    for platform in config.platforms.iter() {
+    for platform in config
+        .platforms
+        .iter()
+        .filter(|x| x.platform != Platform::LinuxMusl)
+    {
         let mut target_dir = config.java_resource_dir();
         target_dir.push(platform.platform.to_string());
         fs::create_dir_all(&target_dir)?;
@@ -125,16 +129,6 @@ fn generate_native_func_class(lib: &Library, config: &JavaBindgenConfig) -> Form
                                 ))
                             })?;
                         }
-                        Platform::Win32 => {
-                            f.writeln("if(org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS && org.apache.commons.lang3.ArchUtils.getProcessor().is32Bit())")?;
-                            blocked(f, |f| {
-                                f.writeln(&format!(
-                                    "loadLibrary(\"{}\", \"{}\", \"dll\");",
-                                    platform.platform.to_string(),
-                                    libname
-                                ))
-                            })?;
-                        }
                         Platform::Linux => {
                             f.writeln("if(org.apache.commons.lang3.SystemUtils.IS_OS_LINUX && org.apache.commons.lang3.ArchUtils.getProcessor().is64Bit())")?;
                             blocked(f, |f| {
@@ -145,6 +139,7 @@ fn generate_native_func_class(lib: &Library, config: &JavaBindgenConfig) -> Form
                                 ))
                             })?;
                         }
+                        Platform::LinuxMusl => (), // We do not generate Java bindings for Linux musl
                     }
                 }
                 Ok(())

--- a/tests/foo-ffi/Cargo.toml
+++ b/tests/foo-ffi/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Émile Grégoire <emile@automatak.com>"]
 edition = "2018"
 
 [lib]
-crate-type = ["rlib", "cdylib"]
+crate-type = ["rlib", "staticlib", "cdylib"]
 
 [dependencies]
 


### PR DESCRIPTION
CI pipeline now builds a musl-based completely static library. It is made available to the C bindings through the `{LIBNAME}_STATIC_MUSL` cache variable.