### PR TITLE
opaque structs

### DIFF
--- a/oo-bindgen/src/native_struct.rs
+++ b/oo-bindgen/src/native_struct.rs
@@ -211,8 +211,8 @@ impl<'a> NativeStructBuilder<'a> {
         }
     }
 
-    pub fn with_type(mut self, struct_type: NativeStructType) -> Self {
-        self.struct_type = struct_type;
+    pub fn make_opaque(mut self) -> Self {
+        self.struct_type = NativeStructType::Opaque;
         self
     }
 

--- a/tests/bindings/dotnet/foo.Tests/OpaqueStructureTest.cs
+++ b/tests/bindings/dotnet/foo.Tests/OpaqueStructureTest.cs
@@ -1,0 +1,17 @@
+using System;
+using Xunit;
+using foo;
+
+namespace foo.Tests
+{
+   
+    public class OpaqueStructureTest
+    {
+        [Fact]
+        public void StructureByValueEchoTest()
+        {            
+            Assert.Equal(42ul, OpaqueStruct.CreateMagicValue().GetId());
+        }
+        
+    }
+}

--- a/tests/bindings/java/foo-tests/src/test/java/io/stepfunc/foo_test/OpaqueStructureTest.java
+++ b/tests/bindings/java/foo-tests/src/test/java/io/stepfunc/foo_test/OpaqueStructureTest.java
@@ -1,0 +1,13 @@
+package io.stepfunc.foo_test;
+
+import io.stepfunc.foo.OpaqueStruct;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import static org.joou.Unsigned.*;
+
+class OpaqueStructTest {
+    @Test
+    void OpaqueStructureCanRoundTripValues() {
+        Assertions.assertEquals(ulong(42), OpaqueStruct.createMagicValue().getId());
+    }
+}

--- a/tests/foo-ffi/src/lib.rs
+++ b/tests/foo-ffi/src/lib.rs
@@ -8,6 +8,7 @@ mod enums;
 mod integer;
 mod iterator;
 mod lifetime;
+mod opaque_struct;
 mod strings;
 mod structure;
 
@@ -19,6 +20,7 @@ pub use enums::*;
 pub use integer::*;
 pub use iterator::*;
 pub use lifetime::*;
+pub(crate) use opaque_struct::*;
 pub use strings::*;
 pub(crate) use structure::*;
 

--- a/tests/foo-ffi/src/opaque_struct.rs
+++ b/tests/foo-ffi/src/opaque_struct.rs
@@ -1,0 +1,7 @@
+pub(crate) unsafe fn opaque_struct_get_id(value: Option<&crate::ffi::OpaqueStruct>) -> u64 {
+    value.unwrap().id
+}
+
+pub(crate) fn opaque_struct_magic_init() -> crate::ffi::OpaqueStruct {
+    crate::ffi::OpaqueStruct { id: 42 }
+}

--- a/tests/foo-schema/src/lib.rs
+++ b/tests/foo-schema/src/lib.rs
@@ -9,6 +9,7 @@ mod enums;
 mod integer;
 mod iterator;
 mod lifetime;
+mod opaque_struct;
 mod strings;
 mod structure;
 
@@ -36,6 +37,7 @@ pub fn build_lib() -> Result<Library, BindingError> {
     enums::define(&mut builder)?;
     integer::define(&mut builder)?;
     iterator::define(&mut builder)?;
+    opaque_struct::define(&mut builder)?;
     strings::define(&mut builder)?;
     structure::define(&mut builder)?;
     lifetime::define(&mut builder)?;

--- a/tests/foo-schema/src/opaque_struct.rs
+++ b/tests/foo-schema/src/opaque_struct.rs
@@ -1,15 +1,41 @@
-use oo_bindgen::native_function::Type;
+use oo_bindgen::native_function::{ReturnType, Type};
 use oo_bindgen::native_struct::NativeStructType;
 use oo_bindgen::*;
 
 pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
     let opaque_struct = lib.declare_native_struct("OpaqueStruct")?;
 
-    lib.define_native_struct(&opaque_struct)?
+    let opaque_struct = lib
+        .define_native_struct(&opaque_struct)?
         .with_type(NativeStructType::Opaque)
         .add("id", Type::Uint64, "64-bit id")?
         .doc("Opaque structure")?
         .build()?;
+
+    let get_id_fn = lib
+        .declare_native_function("opaque_struct_get_id")?
+        .param(
+            "value",
+            Type::StructRef(opaque_struct.declaration.clone()),
+            "struct value",
+        )?
+        .return_type(ReturnType::Type(Type::Uint64, "value of id field".into()))?
+        .doc("Get the id field of the struct")?
+        .build()?;
+
+    let opaque_struct_magic_init_fn = lib
+        .declare_native_function("opaque_struct_magic_init")?
+        .return_type(ReturnType::Type(
+            Type::Struct(opaque_struct.clone()),
+            "initialized value".into(),
+        ))?
+        .doc("Create an OpaqueStruct initialized with a magic id")?
+        .build()?;
+
+    lib.define_struct(&opaque_struct)?
+        .method("GetId", &get_id_fn)?
+        .static_method("CreateMagicValue", &opaque_struct_magic_init_fn)?
+        .build();
 
     Ok(())
 }

--- a/tests/foo-schema/src/opaque_struct.rs
+++ b/tests/foo-schema/src/opaque_struct.rs
@@ -1,0 +1,15 @@
+use oo_bindgen::native_function::Type;
+use oo_bindgen::native_struct::NativeStructType;
+use oo_bindgen::*;
+
+pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
+    let opaque_struct = lib.declare_native_struct("OpaqueStruct")?;
+
+    lib.define_native_struct(&opaque_struct)?
+        .with_type(NativeStructType::Opaque)
+        .add("id", Type::Uint64, "64-bit id")?
+        .doc("Opaque structure")?
+        .build()?;
+
+    Ok(())
+}

--- a/tests/foo-schema/src/opaque_struct.rs
+++ b/tests/foo-schema/src/opaque_struct.rs
@@ -1,5 +1,4 @@
 use oo_bindgen::native_function::{ReturnType, Type};
-use oo_bindgen::native_struct::NativeStructType;
 use oo_bindgen::*;
 
 pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
@@ -7,7 +6,7 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
 
     let opaque_struct = lib
         .define_native_struct(&opaque_struct)?
-        .with_type(NativeStructType::Opaque)
+        .make_opaque()
         .add("id", Type::Uint64, "64-bit id")?
         .doc("Opaque structure")?
         .build()?;


### PR DESCRIPTION
Adds a `make_opaque()` method to `NativeStructBuilder` which is tracked by a `NativeStructType` enum inside the builder and handle type.

This causes the backends to change what they emit:

1) C no longer emits an initializer and warning documentation is added that the type should not be constructed by the user even though technically it cannot be prevented in C.

2) Java and C# make all member fields and constructor private along with docs saying that the type is opaque to the user.

This allows a library API to have opaque types which carry data in the target language. This is useful for things that effectively act as "tokens" carrying some kind of an id and aren't tied to native resource which must be freed.

Resolves https://github.com/stepfunc/oo_bindgen/issues/42