### PR TITLE
Automatic C documentation for Duration type: structs, function parameters, and return values

### DIFF
--- a/generators/c-oo-bindgen/src/lib.rs
+++ b/generators/c-oo-bindgen/src/lib.rs
@@ -595,6 +595,9 @@ fn write_function_docs(
         for param in &handle.parameters {
             f.writeln(&format!("@param {} ", param.name))?;
             docstring_print(f, &param.doc, lib)?;
+            if let Type::Duration(mapping) = param.param_type {
+                f.write(&format!(" ({})", mapping.unit()))?;
+            }
         }
 
         fn write_error_return_doc(f: &mut dyn Printer) -> FormattingResult<()> {
@@ -603,16 +606,22 @@ fn write_function_docs(
 
         match handle.get_type() {
             NativeFunctionType::NoErrorNoReturn => {}
-            NativeFunctionType::NoErrorWithReturn(_, doc) => {
+            NativeFunctionType::NoErrorWithReturn(ret, doc) => {
                 f.writeln("@return ")?;
                 docstring_print(f, &doc, lib)?;
+                if let Type::Duration(mapping) = ret {
+                    f.write(&format!(" ({})", mapping.unit()))?;
+                }
             }
             NativeFunctionType::ErrorNoReturn(_) => {
                 write_error_return_doc(f)?;
             }
-            NativeFunctionType::ErrorWithReturn(_, _, doc) => {
+            NativeFunctionType::ErrorWithReturn(_, ret, doc) => {
                 f.writeln("@param out ")?;
                 docstring_print(f, &doc, lib)?;
+                if let Type::Duration(mapping) = ret {
+                    f.write(&format!(" ({})", mapping.unit()))?;
+                }
                 write_error_return_doc(f)?;
             }
         }

--- a/generators/c-oo-bindgen/src/lib.rs
+++ b/generators/c-oo-bindgen/src/lib.rs
@@ -343,13 +343,17 @@ fn write_struct_definition(
                     StructElementType::OneTimeCallback(_) => None,
                     StructElementType::Iterator(_) => None,
                     StructElementType::Collection(_) => None,
-                    StructElementType::Duration(_, default) => {
-                        default.map(|x| format!("{}s", x.as_secs_f32()))
+                    StructElementType::Duration(mapping, default) => {
+                        default.map(|x| mapping.get_value_string(x))
                     }
                 };
 
                 if let Some(default_value) = default_value {
                     f.writeln(&format!("@note Default value is {}", default_value))?;
+                }
+
+                if let StructElementType::Duration(mapping, _) = &element.element_type {
+                    f.writeln(&format!("@note The unit is {}", mapping.unit()))?;
                 }
 
                 Ok(())

--- a/oo-bindgen/src/native_function.rs
+++ b/oo-bindgen/src/native_function.rs
@@ -2,6 +2,7 @@ use crate::collection::CollectionHandle;
 use crate::doc::{Doc, DocString};
 use crate::iterator::IteratorHandle;
 use crate::*;
+use std::time::Duration;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Type {
@@ -40,6 +41,30 @@ pub enum DurationMapping {
     Seconds,
     // Duration is the number of seconds and fractional part in a f32 value
     SecondsFloat,
+}
+
+impl DurationMapping {
+    pub fn unit(&self) -> &'static str {
+        match self {
+            DurationMapping::Milliseconds => "milliseconds",
+            DurationMapping::Seconds => "seconds",
+            DurationMapping::SecondsFloat => "fractional seconds",
+        }
+    }
+
+    pub fn get_value_string(&self, duration: Duration) -> String {
+        match self {
+            DurationMapping::Milliseconds => {
+                format!("{}", duration.as_millis())
+            }
+            DurationMapping::Seconds => {
+                format!("{}", duration.as_secs())
+            }
+            DurationMapping::SecondsFloat => {
+                format!("{}", duration.as_secs_f32())
+            }
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/tests/foo-schema/src/duration.rs
+++ b/tests/foo-schema/src/duration.rs
@@ -8,13 +8,13 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
         .param(
             "value",
             Type::Duration(DurationMapping::Milliseconds),
-            "Duration (in milliseconds)",
+            "Duration",
         )?
         .return_type(ReturnType::new(
             Type::Duration(DurationMapping::Milliseconds),
-            "Duration (in milliseconds)",
+            "Duration",
         ))?
-        .doc("Echo duration through count of milliseconds")?
+        .doc("Echo duration as count of milliseconds")?
         .build()?;
 
     let duration_s_echo_func = lib
@@ -22,13 +22,13 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
         .param(
             "value",
             Type::Duration(DurationMapping::Seconds),
-            "Duration (in seconds)",
+            "Duration",
         )?
         .return_type(ReturnType::new(
             Type::Duration(DurationMapping::Seconds),
-            "Duration (in seconds)",
+            "Duration",
         ))?
-        .doc("Echo duration through count of seconds")?
+        .doc("Echo duration as count of seconds")?
         .build()?;
 
     let duration_s_float_echo_func = lib
@@ -36,13 +36,13 @@ pub fn define(lib: &mut LibraryBuilder) -> Result<(), BindingError> {
         .param(
             "value",
             Type::Duration(DurationMapping::SecondsFloat),
-            "Duration (in seconds)",
+            "Duration",
         )?
         .return_type(ReturnType::new(
             Type::Duration(DurationMapping::SecondsFloat),
-            "Duration (in seconds)",
+            "Duration",
         ))?
-        .doc("Echo duration through floating point (in seconds)")?
+        .doc("Echo duration as fractional seconds")?
         .build()?;
 
     // Declare static class


### PR DESCRIPTION
C structs now automatically describe the time unit of durations. Default values, if present, are printed in the correct unit:

```
/// @brief duration_millis
/// @note Default value is 4200
/// @note The unit is milliseconds
uint64_t duration_millis;
/// @brief duration_seconds
/// @note Default value is 76
/// @note The unit is seconds
uint64_t duration_seconds;
/// @brief duration_seconds_float
/// @note Default value is 15.25
/// @note The unit is fractional seconds
float duration_seconds_float;
```

Function parameters and return values now get duration units automatically documented:

```
/// @brief Echo duration as count of milliseconds
/// @param value Duration (milliseconds)
/// @return Duration (milliseconds)
uint64_t duration_ms_echo(uint64_t value);

/// @brief Echo duration as count of seconds
/// @param value Duration (seconds)
/// @return Duration (seconds)
uint64_t duration_s_echo(uint64_t value);

/// @brief Echo duration as fractional seconds
/// @param value Duration (fractional seconds)
/// @return Duration (fractional seconds)
float duration_s_float_echo(float value);
```
