### PR TITLE
Add C static bindings to the CI pipeline.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,18 +170,23 @@ jobs:
         with:
           command: run
           args: --release --bin foo-bindings -- --java
-      - name: Upload compiled C bindings (Windows)
+      - name: Upload compiled FFI modules (Windows)
         if: ${{ runner.os == 'Windows' }}
         uses: actions/upload-artifact@v2
         with:
           name: ffi-modules
           path: tests/bindings/c/generated/x86_64-pc-windows-msvc/lib
-      - name: Upload compiled C bindings (Linux)
+      - name: Upload compiled FFI modules (Linux)
         if: ${{ runner.os == 'Linux' }}
         uses: actions/upload-artifact@v2
         with:
           name: ffi-modules
           path: tests/bindings/c/generated/x86_64-unknown-linux-gnu/lib
+      - name: Upload C bindings
+        uses: actions/upload-artifact@v2
+        with:
+          name: c-bindings
+          path: tests/bindings/c/generated
       - name: Upload compiled Java bindings
         uses: actions/upload-artifact@v2
         with:
@@ -225,11 +230,16 @@ jobs:
           use-cross: true
           command: run
           args: --release --target ${{ matrix.target }} --bin foo-bindings -- --c --no-tests
-      - name: Upload compiled C bindings
+      - name: Upload compiled FFI modules
         uses: actions/upload-artifact@v2
         with:
           name: ffi-modules
           path: tests/bindings/c/generated/${{ matrix.target }}/lib
+      - name: Upload C bindings
+        uses: actions/upload-artifact@v2
+        with:
+          name: c-bindings
+          path: tests/bindings/c/generated
   # Package all the generated bindings
   packaging:
     needs: [lock, bindings, cross]
@@ -259,11 +269,6 @@ jobs:
         with:
           command: run
           args: --bin foo-bindings -- --package ./ffi-modules -f dependencies.txt
-      - name: Upload C bindings
-        uses: actions/upload-artifact@v2
-        with:
-          name: c-bindings
-          path: tests/bindings/c/generated
       - name: Upload .NET bindings
         uses: actions/upload-artifact@v2
         with:

--- a/ci-script/Cargo.toml
+++ b/ci-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ci-script"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Émile Grégoire <emile@stepfunc.io>"]
 edition = "2018"
 

--- a/generators/c-oo-bindgen/Cargo.toml
+++ b/generators/c-oo-bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c-oo-bindgen"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Émile Grégoire <emile@stepfunc.io>"]
 edition = "2018"
 

--- a/generators/dotnet-oo-bindgen/Cargo.toml
+++ b/generators/dotnet-oo-bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dotnet-oo-bindgen"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Émile Grégoire <emile@stepfunc.io>"]
 edition = "2018"
 

--- a/generators/dotnet-oo-bindgen/src/lib.rs
+++ b/generators/dotnet-oo-bindgen/src/lib.rs
@@ -39,7 +39,7 @@ clippy::all
 #![forbid(
     unsafe_code,
     //intra_doc_link_resolution_failure, broken_intra_doc_links
-    safe_packed_borrows,
+    unaligned_references,
     while_true,
     bare_trait_objects
 )]

--- a/generators/java-oo-bindgen/Cargo.toml
+++ b/generators/java-oo-bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "java-oo-bindgen"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Émile Grégoire <emile@stepfunc.io>"]
 edition = "2018"
 

--- a/generators/java-oo-bindgen/src/java/mod.rs
+++ b/generators/java-oo-bindgen/src/java/mod.rs
@@ -37,7 +37,7 @@ pub fn generate_java_bindings(lib: &Library, config: &JavaBindgenConfig) -> Form
         .filter(|x| SUPPORTED_PLATFORMS.iter().any(|y| *y == x.platform))
     {
         let mut target_dir = config.java_resource_dir();
-        target_dir.push(platform.platform.to_string());
+        target_dir.push(platform.platform.as_string());
         fs::create_dir_all(&target_dir)?;
 
         let mut source_file = platform.location.clone();
@@ -234,7 +234,7 @@ fn generate_native_func_class(lib: &Library, config: &JavaBindgenConfig) -> Form
                             blocked(f, |f| {
                                 f.writeln(&format!(
                                     "loadLibrary(\"{}\", \"{}\", \"dll\");",
-                                    platform.platform.to_string(),
+                                    platform.platform.as_string(),
                                     libname
                                 ))
                             })?;
@@ -244,7 +244,7 @@ fn generate_native_func_class(lib: &Library, config: &JavaBindgenConfig) -> Form
                             blocked(f, |f| {
                                 f.writeln(&format!(
                                     "loadLibrary(\"{}\", \"lib{}\", \"so\");",
-                                    platform.platform.to_string(),
+                                    platform.platform.as_string(),
                                     libname
                                 ))
                             })?;

--- a/generators/java-oo-bindgen/src/lib.rs
+++ b/generators/java-oo-bindgen/src/lib.rs
@@ -39,7 +39,7 @@ clippy::all
 #![forbid(
     unsafe_code,
     //intra_doc_link_resolution_failure, broken_intra_doc_links
-    safe_packed_borrows,
+    unaligned_references,
     while_true,
     bare_trait_objects
 )]

--- a/generators/rust-oo-bindgen/Cargo.toml
+++ b/generators/rust-oo-bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-oo-bindgen"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Émile Grégoire <emile@stepfunc.io>"]
 edition = "2018"
 

--- a/generators/rust-oo-bindgen/src/lib.rs
+++ b/generators/rust-oo-bindgen/src/lib.rs
@@ -39,7 +39,7 @@ clippy::all
 #![forbid(
     unsafe_code,
     // intra_doc_link_resolution_failure, broken_intra_doc_links
-    safe_packed_borrows,
+    unaligned_references,
     while_true,
     bare_trait_objects
 )]

--- a/oo-bindgen/Cargo.toml
+++ b/oo-bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oo-bindgen"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Émile Grégoire <emile@stepfunc.io>"]
 edition = "2018"
 

--- a/oo-bindgen/src/doc.rs
+++ b/oo-bindgen/src/doc.rs
@@ -420,11 +420,7 @@ fn validate_reference_with_params(
 ) -> Result<(), BindingError> {
     match reference {
         DocReference::Param(param_name) => {
-            if params
-                .iter()
-                .find(|param| &param.name == param_name)
-                .is_none()
-            {
+            if !params.iter().any(|param| &param.name == param_name) {
                 return Err(BindingError::DocInvalidReference {
                     symbol_name: symbol_name.to_string(),
                     ref_name: param_name.to_string(),

--- a/oo-bindgen/src/lib.rs
+++ b/oo-bindgen/src/lib.rs
@@ -39,7 +39,7 @@ clippy::all
 #![forbid(
     unsafe_code,
     //intra_doc_link_resolution_failure, broken_intra_doc_links
-    safe_packed_borrows,
+    unaligned_references,
     while_true,
     bare_trait_objects
 )]

--- a/oo-bindgen/src/platforms.rs
+++ b/oo-bindgen/src/platforms.rs
@@ -36,7 +36,7 @@ impl Platform {
         }
     }
 
-    pub fn to_string(&self) -> &'static str {
+    pub fn as_string(&self) -> &'static str {
         match self {
             Self::WinX64Msvc => "x86_64-pc-windows-msvc",
             Self::LinuxX64Gnu => "x86_64-unknown-linux-gnu",
@@ -60,7 +60,14 @@ impl PlatformLocation {
         Self { platform, location }
     }
 
-    pub fn lib_filename<T: AsRef<str>>(&self, libname: T) -> String {
+    pub fn static_lib_filename<T: AsRef<str>>(&self, libname: T) -> String {
+        match self.platform {
+            Platform::WinX64Msvc => format!("{}.lib", libname.as_ref()),
+            _ => format!("lib{}.a", libname.as_ref()),
+        }
+    }
+
+    pub fn dyn_lib_filename<T: AsRef<str>>(&self, libname: T) -> String {
         match self.platform {
             Platform::WinX64Msvc => format!("{}.dll.lib", libname.as_ref()),
             _ => format!("lib{}.so", libname.as_ref()),

--- a/tests/bindings/c/CMakeLists.txt
+++ b/tests/bindings/c/CMakeLists.txt
@@ -11,14 +11,6 @@ if(UNIX)
 endif()
 find_package(foo REQUIRED)
 
-# You probably don't need do this, just pick either the dynamic or the static
-# one if you are on Linux. Here we do CMake trickery to make it work on the CI.
-if(TARGET foo)
-    set(foo_target foo)
-else()
-    set(foo_target foo_static)
-endif()
-
 set(tests
     ./version_tests.c
     ./enum_tests.c
@@ -32,14 +24,12 @@ set(tests
 )
 
 add_executable(foo_c main.c ${tests})
-target_link_libraries(foo_c PRIVATE ${foo_target})
+target_link_libraries(foo_c PRIVATE foo)
 
-# Copy the DLL after build (if using dynamic)
-if(${foo_target} STREQUAL "foo")
-    add_custom_command(TARGET foo_c POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:foo> $<TARGET_FILE_DIR:foo_c>
-    )
-endif()
+# Copy the DLL after build
+add_custom_command(TARGET foo_c POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:foo> $<TARGET_FILE_DIR:foo_c>
+)
 
 enable_testing()
 add_test(NAME foo_c COMMAND foo_c)

--- a/tests/foo-bindings/src/main.rs
+++ b/tests/foo-bindings/src/main.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 fn main() {
     let builder_settings = ci_script::BindingBuilderSettings {
+        ffi_target_name: "foo-ffi",
         ffi_name: "foo_ffi",
         ffi_path: Path::new("tests/foo-ffi"),
         java_group_id: "io.stepfunc",


### PR DESCRIPTION
Fix #58 

- The CI pipeline now includes static libraries.
- The generated CMake now includes two targets: `foo` and `foo_static`. The first one needs a DLL/.so file to work, while the other wants compiles statically.
- Because static libraries require to explicitly state the system dependencies at link time, the CMake was revised to include all the required system dependencies.
- **Note on Windows**: we currently build the Windows bindings by linking **statically** to the C release runtime. You should therefore use an ABI compliant version of MSVC and link **statically** to the **release** version of the C runtime. This means that you should use the `/MT` flag. If you want to use the dynamic C runtime (`/MD`), you will need to compile the bindings by yourself. I think that Rust cannot link with the debug versions of the runtime, but I can't confirm that.