### PR TITLE
Better C# copying and version check

### DIFF
--- a/deps-config.json
+++ b/deps-config.json
@@ -1,5 +1,5 @@
 {
     "ignore": ["oo-bindgen"],
-    "allowed_licenses": ["Apache-2.0 OR MIT", "MIT OR Unlicense"],
+    "allowed_licenses": ["MIT"],
     "crates": {}
 }

--- a/generators/c-oo-bindgen/src/lib.rs
+++ b/generators/c-oo-bindgen/src/lib.rs
@@ -232,7 +232,7 @@ pub fn generate_doxygen(lib: &Library, config: &CBindgenConfig) -> FormattingRes
             .write_all(&format!("PROJECT_NAME = {}\n", lib.name).into_bytes())
             .unwrap();
         stdin
-            .write_all(&format!("PROJECT_NUMBER = {}\n", lib.version.to_string()).into_bytes())
+            .write_all(&format!("PROJECT_NUMBER = {}\n", lib.version).into_bytes())
             .unwrap();
         stdin.write_all(b"HTML_OUTPUT = doc\n").unwrap();
         stdin.write_all(b"GENERATE_LATEX = NO\n").unwrap();
@@ -292,8 +292,7 @@ fn generate_c_header<P: AsRef<Path>>(lib: &Library, path: P) -> FormattingResult
         ))?;
         f.writeln(&format!(
             "#define {}_VERSION_STRING \"{}\"",
-            uppercase_name,
-            lib.version.to_string()
+            uppercase_name, lib.version
         ))?;
         f.newline()?;
 

--- a/generators/java-oo-bindgen/src/rust/mod.rs
+++ b/generators/java-oo-bindgen/src/rust/mod.rs
@@ -72,7 +72,7 @@ fn generate_toml(lib: &Library, config: &JavaBindgenConfig) -> FormattingResult<
 
     f.writeln("[package]")?;
     f.writeln(&format!("name = \"{}\"", config.java_ffi_name()))?;
-    f.writeln(&format!("version = \"{}\"", lib.version.to_string()))?;
+    f.writeln(&format!("version = \"{}\"", lib.version))?;
     f.writeln("edition = \"2018\"")?;
     f.newline()?;
     f.writeln("[lib]")?;

--- a/oo-bindgen/src/doc.rs
+++ b/oo-bindgen/src/doc.rs
@@ -440,17 +440,13 @@ fn validate_reference_with_params(
                 if handle.find_method(method_name).is_none() {
                     return Err(BindingError::DocInvalidReference {
                         symbol_name: symbol_name.to_string(),
-                        ref_name: format!(
-                            "{}.{}()",
-                            class_name.to_string(),
-                            method_name.to_string()
-                        ),
+                        ref_name: format!("{}.{}()", class_name, method_name),
                     });
                 }
             } else {
                 return Err(BindingError::DocInvalidReference {
                     symbol_name: symbol_name.to_string(),
-                    ref_name: format!("{}.{}()", class_name.to_string(), method_name.to_string()),
+                    ref_name: format!("{}.{}()", class_name, method_name),
                 });
             }
         }
@@ -459,7 +455,7 @@ fn validate_reference_with_params(
                 if handle.constructor.is_none() {
                     return Err(BindingError::DocInvalidReference {
                         symbol_name: symbol_name.to_string(),
-                        ref_name: format!("{}.[constructor]", class_name.to_string(),),
+                        ref_name: format!("{}.[constructor]", class_name),
                     });
                 }
             }
@@ -469,7 +465,7 @@ fn validate_reference_with_params(
                 if handle.destructor.is_none() {
                     return Err(BindingError::DocInvalidReference {
                         symbol_name: symbol_name.to_string(),
-                        ref_name: format!("{}.[destructor]", class_name.to_string(),),
+                        ref_name: format!("{}.[destructor]", class_name),
                     });
                 }
             }
@@ -487,17 +483,13 @@ fn validate_reference_with_params(
                 if handle.find_element(method_name).is_none() {
                     return Err(BindingError::DocInvalidReference {
                         symbol_name: symbol_name.to_string(),
-                        ref_name: format!(
-                            "{}.{}",
-                            struct_name.to_string(),
-                            method_name.to_string()
-                        ),
+                        ref_name: format!("{}.{}", struct_name, method_name),
                     });
                 }
             } else {
                 return Err(BindingError::DocInvalidReference {
                     symbol_name: symbol_name.to_string(),
-                    ref_name: format!("{}.{}", struct_name.to_string(), method_name.to_string()),
+                    ref_name: format!("{}.{}", struct_name, method_name),
                 });
             }
         }
@@ -506,17 +498,13 @@ fn validate_reference_with_params(
                 if handle.find_method(element_name).is_none() {
                     return Err(BindingError::DocInvalidReference {
                         symbol_name: symbol_name.to_string(),
-                        ref_name: format!(
-                            "{}.{}()",
-                            struct_name.to_string(),
-                            element_name.to_string()
-                        ),
+                        ref_name: format!("{}.{}()", struct_name, element_name),
                     });
                 }
             } else {
                 return Err(BindingError::DocInvalidReference {
                     symbol_name: symbol_name.to_string(),
-                    ref_name: format!("{}.{}()", struct_name.to_string(), element_name.to_string()),
+                    ref_name: format!("{}.{}()", struct_name, element_name),
                 });
             }
         }
@@ -533,13 +521,13 @@ fn validate_reference_with_params(
                 if handle.find_variant_by_name(variant_name).is_none() {
                     return Err(BindingError::DocInvalidReference {
                         symbol_name: symbol_name.to_string(),
-                        ref_name: format!("{}.{}", enum_name.to_string(), variant_name.to_string()),
+                        ref_name: format!("{}.{}", enum_name, variant_name),
                     });
                 }
             } else {
                 return Err(BindingError::DocInvalidReference {
                     symbol_name: symbol_name.to_string(),
-                    ref_name: format!("{}.{}", enum_name.to_string(), variant_name.to_string()),
+                    ref_name: format!("{}.{}", enum_name, variant_name),
                 });
             }
         }
@@ -556,21 +544,13 @@ fn validate_reference_with_params(
                 if handle.find_callback(method_name).is_none() {
                     return Err(BindingError::DocInvalidReference {
                         symbol_name: symbol_name.to_string(),
-                        ref_name: format!(
-                            "{}.{}()",
-                            interface_name.to_string(),
-                            method_name.to_string()
-                        ),
+                        ref_name: format!("{}.{}()", interface_name, method_name),
                     });
                 }
             } else {
                 return Err(BindingError::DocInvalidReference {
                     symbol_name: symbol_name.to_string(),
-                    ref_name: format!(
-                        "{}.{}()",
-                        interface_name.to_string(),
-                        method_name.to_string()
-                    ),
+                    ref_name: format!("{}.{}()", interface_name, method_name),
                 });
             }
         }

--- a/oo-bindgen/src/lib.rs
+++ b/oo-bindgen/src/lib.rs
@@ -648,7 +648,13 @@ impl LibraryBuilder {
         }
     }
 
-    pub fn build(self) -> Result<Library> {
+    pub fn build(mut self) -> Result<Library> {
+        // Add the version function
+        self.declare_native_function("version")?
+            .return_type(ReturnType::new(Type::String, "Version number"))?
+            .doc("Get the version of the library as a string")?
+            .build()?;
+
         // Update all native structs to full structs
         let mut structs = HashMap::with_capacity(self.defined_structs.len());
         for structure in self.defined_structs.values() {

--- a/tests/foo-ffi/src/lib.rs
+++ b/tests/foo-ffi/src/lib.rs
@@ -27,3 +27,9 @@ pub use strings::*;
 pub(crate) use structure::*;
 
 pub mod ffi;
+
+static VERSION: &str = concat!("1.2.3", "\0");
+
+fn version() -> &'static std::ffi::CStr {
+    unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(VERSION.as_bytes()) }
+}


### PR DESCRIPTION
- C# now includes targets to properly copy the Windows DLL when consumed as
  a NuGet package on .NET Framework.
- C# and Java now checks that the version number of the source code is the same
  as the loaded module.

Fix https://github.com/stepfunc/dnp3/issues/147