### PR TITLE
Struct initializer comments overhaul

### DIFF
--- a/generators/c-oo-bindgen/src/cpp/doc.rs
+++ b/generators/c-oo-bindgen/src/cpp/doc.rs
@@ -8,6 +8,13 @@ pub(crate) fn print_cpp_doc(f: &mut dyn Printer, doc: &Doc<Validated>) -> Format
     doxygen_print_generic(f, print_cpp_reference, doc)
 }
 
+pub(crate) fn print_cpp_docstring(
+    f: &mut dyn Printer,
+    docstring: &DocString<Validated>,
+) -> FormattingResult<()> {
+    docstring_print_generic(f, print_cpp_reference, docstring)
+}
+
 pub(crate) fn print_cpp_method_docs(
     f: &mut dyn Printer,
     method: &Method<Validated>,

--- a/generators/c-oo-bindgen/src/lib.rs
+++ b/generators/c-oo-bindgen/src/lib.rs
@@ -164,7 +164,8 @@ fn generate_doxygen(lib: &Library, config: &CBindgenConfig) -> FormattingResult<
             // Output customization
             "GENERATE_LATEX = NO",                          // No LaTeX
             "EXTRACT_STATIC = YES",                         // We want all functions
-            "TYPEDEF_HIDES_STRUCT = YES",                   // To avoid a large
+            "TYPEDEF_HIDES_STRUCT = YES",                   // To avoid a large typedef table
+            "AUTOLINK_SUPPORT = NO",                        // Only link when we explicitly want to
             "OPTIMIZE_OUTPUT_FOR_C = YES",                  // I guess this will help the output
             "ALWAYS_DETAILED_SEC = YES",                    // Always print detailed section
             &format!("STRIP_FROM_PATH = {}", include_path), // Remove include path

--- a/generators/dotnet-oo-bindgen/src/lib.rs
+++ b/generators/dotnet-oo-bindgen/src/lib.rs
@@ -553,6 +553,7 @@ fn generate_doxygen(lib: &Library, config: &DotnetBindgenConfig) -> FormattingRe
             "GENERATE_LATEX = NO",       // No LaTeX
             "HIDE_UNDOC_CLASSES = YES",  // I guess this will help the output
             "ALWAYS_DETAILED_SEC = YES", // Always print detailed section
+            "AUTOLINK_SUPPORT = NO",     // Only link when we explicitly want to
             // Styling
             "HTML_EXTRA_STYLESHEET = doxygen-awesome.css",
             "GENERATE_TREEVIEW = YES",


### PR DESCRIPTION
- Disable doxygen auto-linking in C and .NET (keeping it in C++ as a workaround of doxygen numerous reference bugs)
- Add struct initializer default values in the docs of C# and Java
- Add parameters documentation for initializers in C and C++
- Upgraded a few refs to actual references