### PR TITLE
Drop-safe futures

### DIFF
--- a/oo-bindgen/src/backend/dotnet/interface.rs
+++ b/oo-bindgen/src/backend/dotnet/interface.rs
@@ -228,26 +228,24 @@ pub(crate) fn generate(
                 blocked(f, |f| f.writeln("Task.Run(() => tcs.SetResult(value));"))?;
                 f.newline()?;
 
-                if let Some(err) = fi.error_type.get() {
-                    let error_method_name = fi
-                        .interface
-                        .settings
-                        .future
-                        .failure_callback_method_name
-                        .camel_case();
+                let error_method_name = fi
+                    .interface
+                    .settings
+                    .future
+                    .failure_callback_method_name
+                    .camel_case();
+                f.writeln(&format!(
+                    "void {}.{}({} err)",
+                    interface_name,
+                    error_method_name,
+                    fi.error_type.inner.get_dotnet_type()
+                ))?;
+                blocked(f, |f| {
                     f.writeln(&format!(
-                        "void {}.{}({} err)",
-                        interface_name,
-                        error_method_name,
-                        err.inner.get_dotnet_type()
-                    ))?;
-                    blocked(f, |f| {
-                        f.writeln(&format!(
-                            "Task.Run(() => tcs.SetException(new {}(err)));",
-                            err.exception_name.camel_case()
-                        ))
-                    })?;
-                }
+                        "Task.Run(() => tcs.SetException(new {}(err)));",
+                        fi.error_type.exception_name.camel_case()
+                    ))
+                })?;
 
                 Ok(())
             })?;

--- a/oo-bindgen/src/backend/java/api/class.rs
+++ b/oo-bindgen/src/backend/java/api/class.rs
@@ -415,20 +415,18 @@ fn generate_async_method(
             ))?;
             blocked(f, |f| f.writeln("_future.complete(value);"))?;
 
-            if let Some(err) = method.future.error_type.get() {
-                f.newline()?;
+            f.newline()?;
+            f.writeln(&format!(
+                "public void {}({} error)",
+                settings.future.failure_callback_method_name.mixed_case(),
+                method.future.error_type.inner.name.camel_case()
+            ))?;
+            blocked(f, |f| {
                 f.writeln(&format!(
-                    "public void {}({} error)",
-                    settings.future.failure_callback_method_name.mixed_case(),
-                    err.inner.name.camel_case()
-                ))?;
-                blocked(f, |f| {
-                    f.writeln(&format!(
-                        "_future.completeExceptionally(new {}(error));",
-                        err.exception_name.camel_case()
-                    ))
-                })?;
-            }
+                    "_future.completeExceptionally(new {}(error));",
+                    method.future.error_type.exception_name.camel_case()
+                ))
+            })?;
 
             Ok(())
         })?;

--- a/oo-bindgen/src/backend/rust/mod.rs
+++ b/oo-bindgen/src/backend/rust/mod.rs
@@ -43,6 +43,7 @@ impl<'a> RustCodegen<'a> {
 
     fn write_promise_module(f: &mut dyn Printer) -> FormattingResult<()> {
         let promise = include_str!("../../../static/rust/promise.rs");
+        f.writeln("#[allow(dead_code)]")?;
         f.writeln("pub(crate) mod promise {")?;
         indented(f, |f| {
             for line in promise.lines() {

--- a/oo-bindgen/src/backend/rust/mod.rs
+++ b/oo-bindgen/src/backend/rust/mod.rs
@@ -557,11 +557,6 @@ impl<'a> RustCodegen<'a> {
                 "type Error = {};",
                 handle.error_type.inner.name.to_upper_camel_case()
             ))?;
-            f.writeln(&format!(
-                "const ERROR_ON_DROP: Self::Error = {}::{};",
-                handle.drop_variant.handle.name.to_upper_camel_case(),
-                handle.drop_variant.variant.name.to_upper_camel_case()
-            ))?;
 
             f.newline()?;
             f.writeln("fn success(&self, value: Self::Value) {")?;

--- a/oo-bindgen/src/backend/rust/mod.rs
+++ b/oo-bindgen/src/backend/rust/mod.rs
@@ -9,9 +9,9 @@ use crate::model::*;
 
 use crate::backend::rust::rust_struct::RustStruct;
 use crate::backend::rust::rust_type::RustType;
-use crate::backend::rust::type_converter::TypeConverter;
 
 use crate::backend::rust::rust_type::LifetimeInfo;
+use crate::backend::rust::type_converter::TypeConverter;
 
 mod rust_struct;
 mod rust_type;
@@ -41,8 +41,23 @@ impl<'a> RustCodegen<'a> {
         }
     }
 
+    fn write_promise_module(f: &mut dyn Printer) -> FormattingResult<()> {
+        let promise = include_str!("../../../static/rust/promise.rs");
+        f.writeln("pub(crate) mod promise {")?;
+        indented(f, |f| {
+            for line in promise.lines() {
+                f.writeln(line)?;
+            }
+            Ok(())
+        })?;
+        f.writeln("}")?;
+        Ok(())
+    }
+
     fn generate(self) -> FormattingResult<()> {
         let mut f = FilePrinter::new(&self.dest_path)?;
+
+        Self::write_promise_module(&mut f)?;
 
         for statement in self.library.statements() {
             match statement {
@@ -57,7 +72,10 @@ impl<'a> RustCodegen<'a> {
                     Self::write_function(&mut f, handle, &self.library.settings.c_ffi_prefix)?
                 }
                 Statement::InterfaceDefinition(t) => {
-                    self.write_interface(&mut f, t.untyped(), t.mode())?
+                    self.write_interface(&mut f, t.untyped(), t.mode())?;
+                    if let InterfaceType::Future(t) = t {
+                        self.write_future_helpers(&mut f, t)?;
+                    }
                 }
                 _ => (),
             }
@@ -325,7 +343,6 @@ impl<'a> RustCodegen<'a> {
             _error: &ErrorType<Validated>,
         ) -> FormattingResult<()> {
             f.write(") -> std::os::raw::c_int")
-            //f.write(&format!(") -> {}", error.inner.name.to_upper_camel_case()))
         }
 
         // write the return type
@@ -517,7 +534,47 @@ impl<'a> RustCodegen<'a> {
                     ))
                 })
             })
-        })
+        })?;
+
+        Ok(())
+    }
+
+    fn write_future_helpers(
+        &self,
+        f: &mut dyn Printer,
+        handle: &FutureInterface<Validated>,
+    ) -> FormattingResult<()> {
+        let name = handle.interface.name.to_upper_camel_case();
+        f.writeln(&format!(
+            "impl crate::ffi::promise::FutureInterface for {name}"
+        ))?;
+        blocked(f, |f| {
+            f.writeln(&format!(
+                "type Value = {};",
+                handle.value_type.as_rust_type()
+            ))?;
+            f.writeln(&format!(
+                "type Error = {};",
+                handle.error_type.inner.name.to_upper_camel_case()
+            ))?;
+            f.writeln(&format!(
+                "const ERROR_ON_DROP: Self::Error = {}::{};",
+                handle.drop_variant.handle.name.to_upper_camel_case(),
+                handle.drop_variant.variant.name.to_upper_camel_case()
+            ))?;
+
+            f.newline()?;
+            f.writeln("fn success(&self, value: Self::Value) {")?;
+            indented(f, |f| f.writeln("self.on_complete(value);"))?;
+            f.writeln("}")?;
+
+            f.newline()?;
+            f.writeln("fn error(&self, value: Self::Error) {")?;
+            indented(f, |f| f.writeln("self.on_failure(value);"))?;
+            f.writeln("}")?;
+            Ok(())
+        })?;
+        Ok(())
     }
 
     fn write_callback_helpers<'b, I: Iterator<Item = &'b CallbackFunction<Validated>>>(

--- a/oo-bindgen/src/backend/rust/rust_type.rs
+++ b/oo-bindgen/src/backend/rust/rust_type.rs
@@ -374,7 +374,11 @@ where
     }
 
     fn conversion(&self) -> Option<TypeConverter> {
-        None
+        match self.mode {
+            InterfaceCategory::Synchronous => None,
+            InterfaceCategory::Asynchronous => None,
+            InterfaceCategory::Future => Some(TypeConverter::FutureInterface),
+        }
     }
 }
 

--- a/oo-bindgen/src/backend/rust/type_converter.rs
+++ b/oo-bindgen/src/backend/rust/type_converter.rs
@@ -15,6 +15,7 @@ pub(crate) enum TypeConverter {
     UnvalidatedEnum(Handle<Enum<Unvalidated>>),
     Struct(StructDeclarationHandle),
     Duration(DurationType),
+    FutureInterface,
 }
 
 impl TypeConverter {
@@ -30,6 +31,7 @@ impl TypeConverter {
             TypeConverter::UnvalidatedEnum(x) => x.convert_to_c(f, from, to),
             TypeConverter::Struct(x) => x.convert_to_c(f, from, to),
             TypeConverter::Duration(x) => x.convert_to_c(f, from, to),
+            TypeConverter::FutureInterface => unimplemented!(),
         }
     }
 
@@ -45,6 +47,9 @@ impl TypeConverter {
             TypeConverter::UnvalidatedEnum(x) => x.convert_from_c(f, from, to),
             TypeConverter::Struct(x) => x.convert_from_c(f, from, to),
             TypeConverter::Duration(x) => x.convert_from_c(f, from, to),
+            TypeConverter::FutureInterface => {
+                f.writeln(&format!("{to} crate::ffi::promise::wrap({from})"))
+            }
         }
     }
 
@@ -55,6 +60,9 @@ impl TypeConverter {
             TypeConverter::UnvalidatedEnum(x) => x.is_unsafe(),
             TypeConverter::Struct(x) => x.is_unsafe(),
             TypeConverter::Duration(x) => x.is_unsafe(),
+            TypeConverter::FutureInterface => {
+                todo!()
+            }
         }
     }
 }

--- a/oo-bindgen/src/model/builder/library.rs
+++ b/oo-bindgen/src/model/builder/library.rs
@@ -489,9 +489,7 @@ impl LibraryBuilder {
         value_type: V,
         value_type_docs: E,
         error_type: ErrorType<Unvalidated>,
-        drop_variant: &'static str,
     ) -> BindResult<FutureInterface<Unvalidated>> {
-        let drop_variant = error_type.inner.value(drop_variant)?;
         let value_type = value_type.into();
         let value_type_docs = value_type_docs.into();
         let name = name.into_name()?;
@@ -528,13 +526,7 @@ impl LibraryBuilder {
             .end_callback()?;
 
         let (interface, lib) = builder.build(InterfaceCategory::Future);
-        let ret = FutureInterface::new(
-            value_type,
-            error_type,
-            interface,
-            value_type_docs,
-            drop_variant,
-        );
+        let ret = FutureInterface::new(value_type, error_type, interface, value_type_docs);
         lib.add_statement(Statement::InterfaceDefinition(InterfaceType::Future(
             ret.clone(),
         )))?;

--- a/oo-bindgen/src/model/interface.rs
+++ b/oo-bindgen/src/model/interface.rs
@@ -444,22 +444,25 @@ where
 {
     pub(crate) value_type: CallbackArgument,
     pub(crate) value_type_doc: DocString<D>,
-    pub(crate) error_type: OptionalErrorType<D>,
+    pub(crate) error_type: ErrorType<D>,
     pub(crate) interface: Handle<Interface<D>>,
+    pub(crate) drop_variant: EnumValue,
 }
 
 impl FutureInterface<Unvalidated> {
     pub(crate) fn new(
         value_type: CallbackArgument,
-        error_type: OptionalErrorType<Unvalidated>,
+        error_type: ErrorType<Unvalidated>,
         interface: Handle<Interface<Unvalidated>>,
         value_type_doc: DocString<Unvalidated>,
+        drop_variant: EnumValue,
     ) -> Self {
         Self {
             value_type,
             error_type,
             value_type_doc,
             interface,
+            drop_variant,
         }
     }
 
@@ -469,6 +472,7 @@ impl FutureInterface<Unvalidated> {
             error_type: self.error_type.validate(lib)?,
             value_type_doc: self.value_type_doc.validate(&self.interface.name, lib)?,
             interface: self.interface.validate(lib)?,
+            drop_variant: self.drop_variant.clone(),
         })
     }
 }

--- a/oo-bindgen/src/model/interface.rs
+++ b/oo-bindgen/src/model/interface.rs
@@ -446,7 +446,6 @@ where
     pub(crate) value_type_doc: DocString<D>,
     pub(crate) error_type: ErrorType<D>,
     pub(crate) interface: Handle<Interface<D>>,
-    pub(crate) drop_variant: EnumValue,
 }
 
 impl FutureInterface<Unvalidated> {
@@ -455,14 +454,12 @@ impl FutureInterface<Unvalidated> {
         error_type: ErrorType<Unvalidated>,
         interface: Handle<Interface<Unvalidated>>,
         value_type_doc: DocString<Unvalidated>,
-        drop_variant: EnumValue,
     ) -> Self {
         Self {
             value_type,
             error_type,
             value_type_doc,
             interface,
-            drop_variant,
         }
     }
 
@@ -472,7 +469,6 @@ impl FutureInterface<Unvalidated> {
             error_type: self.error_type.validate(lib)?,
             value_type_doc: self.value_type_doc.validate(&self.interface.name, lib)?,
             interface: self.interface.validate(lib)?,
-            drop_variant: self.drop_variant.clone(),
         })
     }
 }

--- a/oo-bindgen/static/rust/promise.rs
+++ b/oo-bindgen/static/rust/promise.rs
@@ -1,8 +1,10 @@
+pub(crate) trait DropError {
+    const ERROR_ON_DROP: Self;
+}
+
 pub(crate) trait FutureInterface : Sized  + Send + 'static {
     type Value;
-    type Error;
-
-    const ERROR_ON_DROP : Self::Error;
+    type Error: DropError;
 
     fn success(&self, value: Self::Value);
     fn error(&self, err: Self::Error);
@@ -36,7 +38,7 @@ impl<T> Promise<Result<T::Value, T::Error>> for PromiseImpl<T> where T: FutureIn
 impl<T> Drop for PromiseImpl<T> where T: FutureInterface {
     fn drop(&mut self) {
         if let Some(x) = self.inner.take() {
-            x.error(T::ERROR_ON_DROP);
+            x.error(T::Error::ERROR_ON_DROP);
         }
     }
 }

--- a/oo-bindgen/static/rust/promise.rs
+++ b/oo-bindgen/static/rust/promise.rs
@@ -1,0 +1,42 @@
+pub(crate) trait FutureInterface : Sized  + Send + 'static {
+    type Value;
+    type Error;
+
+    const ERROR_ON_DROP : Self::Error;
+
+    fn success(&self, value: Self::Value);
+    fn error(&self, err: Self::Error);
+}
+
+pub(crate) trait Promise<T> : Send + 'static {
+    fn complete(&mut self, value: T);
+}
+
+pub(crate) fn wrap<V, E>(interface: impl FutureInterface<Error=E, Value=V>) -> impl Promise<Result<V, E>> {
+    PromiseImpl {
+        inner: Some(interface),
+    }
+}
+
+struct PromiseImpl<T>  where T: FutureInterface {
+    inner: Option<T>,
+}
+
+impl<T> Promise<Result<T::Value, T::Error>> for PromiseImpl<T> where T: FutureInterface {
+    fn complete(&mut self, res: Result<T::Value, T::Error>) {
+        if let Some(x) = self.inner.take() {
+            match res {
+                Ok(v) => x.success(v),
+                Err(err) => x.error(err),
+            }
+        }
+    }
+}
+
+impl<T> Drop for PromiseImpl<T> where T: FutureInterface {
+    fn drop(&mut self) {
+        if let Some(x) = self.inner.take() {
+            x.error(T::ERROR_ON_DROP);
+        }
+    }
+}

--- a/tests/bindings/c/cpp_tests/thread_tests.cpp
+++ b/tests/bindings/c/cpp_tests/thread_tests.cpp
@@ -74,6 +74,26 @@ static void test_async_callbacks()
             assert(result.is_error);
             assert(result.error == foo::MathIsBroken::math_is_broke);
         }
+
+        {
+            tc.queue_error(foo::MathIsBroken::math_is_broke);
+            auto promise = std::make_shared<std::promise<AddResult>>();
+            auto future = promise->get_future();
+            tc.add(3, std::make_unique<AddHandler>(promise));
+            auto result = future.get();
+            assert(result.is_error);
+            assert(result.error == foo::MathIsBroken::math_is_broke);
+        }
+
+        {
+            tc.drop_next_add();
+            auto promise = std::make_shared<std::promise<AddResult>>();
+            auto future = promise->get_future();
+            tc.add(3, std::make_unique<AddHandler>(promise));
+            auto result = future.get();
+            assert(result.is_error);
+            assert(result.error == foo::MathIsBroken::dropped);
+        }
         
         tc.execute(foo::functional::operation([](uint32_t value) { return 2 * value; }));
     }

--- a/tests/bindings/dotnet/foo.Tests/ClassTest.cs
+++ b/tests/bindings/dotnet/foo.Tests/ClassTest.cs
@@ -21,19 +21,6 @@ namespace foo.Tests
             testclass.Shutdown();
 
             Assert.Equal(0u, TestClass.ConstructionCounter());
-        }
-
-        [Fact]
-        public async void AsyncMethodTest()
-        {
-            var testclass = new TestClass(41);
-            Assert.Equal(1u, TestClass.ConstructionCounter());
-            Assert.Equal(42u, await testclass.AddAsync(1));
-
-            testclass.IncrementValue();
-            Assert.Equal(43u, await testclass.AddAsync(1));
-
-            testclass.Shutdown();
-        }
+        }       
     }
 }

--- a/tests/bindings/dotnet/foo.Tests/ThreadTest.cs
+++ b/tests/bindings/dotnet/foo.Tests/ThreadTest.cs
@@ -49,5 +49,29 @@ namespace foo.Tests
 
             Assert.Empty(values);
         }
+
+        [Fact]
+        public async void PromiseCanCompleteIfDropped()
+        {
+            var values = new List<uint>();
+            var tc = new foo.ThreadClass(42, item => values.Add(item));
+            tc.DropNextAdd();
+
+            try
+            {
+                var result = await tc.Add(43);
+                Assert.True(false);
+            }
+            catch (BrokenMathException ex)
+            {
+                Assert.Equal(MathIsBroken.Dropped, ex.error);
+            }
+            finally
+            {
+                tc.Shutdown();
+            }
+
+            Assert.Empty(values);
+        }
     }
 }

--- a/tests/bindings/java/foo-tests/src/test/java/io/stepfunc/foo_test/ClassTest.java
+++ b/tests/bindings/java/foo-tests/src/test/java/io/stepfunc/foo_test/ClassTest.java
@@ -24,16 +24,4 @@ public class ClassTest {
 
         assertThat(TestClass.constructionCounter().intValue()).isZero();
     }
-
-    @Test
-    public void AsyncMethodTest() throws ExecutionException, InterruptedException {
-        TestClass testclass = new TestClass(uint(41));
-        assertThat(TestClass.constructionCounter()).isEqualTo(uint(1));
-        assertThat(testclass.addAsync(uint(1)).toCompletableFuture().get()).isEqualTo(uint(42));
-
-        testclass.incrementValue();
-        assertThat(testclass.addAsync(uint(1)).toCompletableFuture().get()).isEqualTo(uint(43));
-
-        testclass.shutdown();
-    }
 }

--- a/tests/bindings/java/foo-tests/src/test/java/io/stepfunc/foo_test/ThreadTest.java
+++ b/tests/bindings/java/foo-tests/src/test/java/io/stepfunc/foo_test/ThreadTest.java
@@ -57,4 +57,25 @@ class ThreadTest {
             tc.shutdown();
         }
     }
+
+    @Test
+    void promiseStillCompletesIfDropped() throws Exception {
+
+        ThreadClass tc = new ThreadClass(uint(42), v -> {});
+        tc.dropNextAdd();
+
+        try {
+            tc.dropNextAdd();
+            UInteger result = tc.add(uint(4)).toCompletableFuture().get();
+            fail("Exception not thrown");
+        }
+        catch(ExecutionException ex) {
+            BrokenMathException cause = (BrokenMathException) ex.getCause();
+            assertThat(cause.error).isEqualTo(MathIsBroken.DROPPED);
+        }
+        finally {
+            // explicitly shutdown the thread so that we can test post conditions
+            tc.shutdown();
+        }
+    }
 }

--- a/tests/foo-ffi/src/class.rs
+++ b/tests/foo-ffi/src/class.rs
@@ -1,5 +1,3 @@
-use crate::ffi;
-
 static mut CONSTRUCTION_COUNTER: u32 = 0;
 
 pub struct TestClass {
@@ -27,15 +25,6 @@ pub unsafe fn test_class_get_value(testclass: *const TestClass) -> u32 {
 pub unsafe fn test_class_increment_value(testclass: *mut TestClass) {
     let testclass = testclass.as_mut().unwrap();
     testclass.value += 1;
-}
-
-pub unsafe fn test_class_add_async(
-    testclass: *const TestClass,
-    value: u32,
-    cb: ffi::GetValueCallback,
-) {
-    let testclass = testclass.as_ref().unwrap();
-    cb.on_complete(testclass.value + value);
 }
 
 pub unsafe fn construction_counter() -> u32 {

--- a/tests/foo-ffi/src/lib.rs
+++ b/tests/foo-ffi/src/lib.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::missing_safety_doc)]
 
+extern crate alloc;
+
 pub use callback::*;
 pub use class::*;
 pub use collection::*;

--- a/tests/foo-ffi/src/thread_class.rs
+++ b/tests/foo-ffi/src/thread_class.rs
@@ -1,4 +1,5 @@
-use crate::ffi::promise::Promise;
+use crate::ffi::promise::{DropError, Promise};
+use crate::ffi::MathIsBroken;
 use std::thread::JoinHandle;
 
 enum Message {
@@ -101,6 +102,10 @@ pub(crate) unsafe fn thread_class_update(instance: *mut ThreadClass, value: u32)
     if let Some(x) = instance.as_ref() {
         x.tx.send(Message::Update(value)).unwrap()
     }
+}
+
+impl DropError for MathIsBroken {
+    const ERROR_ON_DROP: Self = Self::Dropped;
 }
 
 pub(crate) unsafe fn thread_class_add(

--- a/tests/foo-ffi/src/thread_class.rs
+++ b/tests/foo-ffi/src/thread_class.rs
@@ -1,9 +1,14 @@
+use crate::ffi::promise::Promise;
 use std::thread::JoinHandle;
 
 enum Message {
     Update(u32),
-    Add(u32, crate::ffi::AddHandler),
+    Add(
+        u32,
+        Box<dyn Promise<Result<u32, crate::ffi::MathIsBroken>> + Send>,
+    ),
     QueueAddError(crate::ffi::MathIsBroken),
+    DropAdd,
     Operation(crate::ffi::Operation),
     Stop,
 }
@@ -11,6 +16,7 @@ enum Message {
 struct ThreadData {
     value: u32,
     error_queue: Vec<crate::ffi::MathIsBroken>,
+    drop_add: bool,
     receiver: crate::ffi::ValueChangeListener,
     rx: std::sync::mpsc::Receiver<Message>,
 }
@@ -41,13 +47,16 @@ fn run(mut data: ThreadData) {
                 data.value = x;
                 data.receiver.on_value_change(x);
             }
-            Message::Add(x, cb) => {
-                if let Some(err) = data.error_queue.pop() {
-                    cb.on_failure(err);
+            Message::Add(x, mut reply) => {
+                if data.drop_add {
+                    // we don't reply at all, we just let the promise drop
+                    data.drop_add = false;
+                } else if let Some(err) = data.error_queue.pop() {
+                    reply.complete(Err(err));
                 } else {
                     data.value += x;
                     data.receiver.on_value_change(data.value);
-                    cb.on_complete(data.value);
+                    reply.complete(Ok(data.value));
                 }
             }
             Message::Operation(op) => {
@@ -58,6 +67,9 @@ fn run(mut data: ThreadData) {
             }
             Message::Stop => return,
             Message::QueueAddError(err) => data.error_queue.push(err),
+            Message::DropAdd => {
+                data.drop_add = true;
+            }
         }
     }
 }
@@ -70,6 +82,7 @@ pub(crate) fn thread_class_create(
     let thread_data = ThreadData {
         value,
         error_queue: Default::default(),
+        drop_add: false,
         receiver,
         rx,
     };
@@ -93,10 +106,10 @@ pub(crate) unsafe fn thread_class_update(instance: *mut ThreadClass, value: u32)
 pub(crate) unsafe fn thread_class_add(
     instance: *mut ThreadClass,
     value: u32,
-    callback: crate::ffi::AddHandler,
+    callback: impl crate::ffi::promise::Promise<Result<u32, crate::ffi::MathIsBroken>>,
 ) {
     if let Some(x) = instance.as_ref() {
-        x.tx.send(Message::Add(value, callback)).unwrap()
+        x.tx.send(Message::Add(value, Box::new(callback))).unwrap()
     }
 }
 
@@ -115,5 +128,11 @@ pub(crate) unsafe fn thread_class_queue_error(
 ) {
     if let Some(x) = instance.as_ref() {
         x.tx.send(Message::QueueAddError(err)).unwrap()
+    }
+}
+
+pub(crate) unsafe fn thread_class_drop_next_add(instance: *mut crate::ThreadClass) {
+    if let Some(x) = instance.as_ref() {
+        x.tx.send(Message::DropAdd).unwrap()
     }
 }

--- a/tests/foo-schema/src/class.rs
+++ b/tests/foo-schema/src/class.rs
@@ -32,24 +32,6 @@ pub fn define(lib: &mut LibraryBuilder) -> BackTraced<()> {
         .doc("Increment value")?
         .build()?;
 
-    let get_value_callback = lib.define_future_interface(
-        "get_value_callback",
-        "GetValue callback handler",
-        Primitive::U32,
-        "Result of the operation",
-        None,
-    )?;
-
-    let get_value_async = lib
-        .define_future_method("add_async", test_class.clone(), get_value_callback)?
-        .param(
-            "value",
-            Primitive::U32,
-            "value to add to the internal value",
-        )?
-        .doc("add a number to the class's internal value asynchronously")?
-        .build()?;
-
     let construction_counter = lib
         .define_function("construction_counter")?
         .returns(Primitive::U32, "Number of calls to the constructor")?
@@ -63,7 +45,6 @@ pub fn define(lib: &mut LibraryBuilder) -> BackTraced<()> {
         .destructor(destructor)?
         .method(get_value)?
         .method(increment_value)?
-        .async_method(get_value_async)?
         .static_method(construction_counter)?
         .custom_destroy("shutdown")?
         .doc("A test class")?

--- a/tests/foo-schema/src/thread_class.rs
+++ b/tests/foo-schema/src/thread_class.rs
@@ -11,6 +11,7 @@ pub fn define(lib: &mut LibraryBuilder) -> BackTraced<()> {
             ExceptionType::CheckedException,
         )?
         .add_error("math_is_broke", "hey, sometime is happens")?
+        .add_error("dropped", "callback was dropped")?
         .doc("sometime math just doesn't work")?
         .build()?;
 
@@ -82,13 +83,20 @@ pub fn define(lib: &mut LibraryBuilder) -> BackTraced<()> {
         .doc("Next time {class:thread_class.add()} is called, fail it with this error")?
         .build()?;
 
+    let drop_next_add = lib
+        .define_method("drop_next_add", thread_class.clone())?
+        .doc("Next time {class:thread_class.add()} is called, the callback promise will just get dropped")?
+        .build()?;
+
     let add_handler = lib.define_future_interface(
         "add_handler",
         "receives a single value from an add operation",
         Primitive::U32,
         "result of the add operation",
-        Some(error_type),
+        error_type,
+        "dropped",
     )?;
+
     let add_async = lib
         .define_future_method("add", thread_class.clone(), add_handler)?
         .param(
@@ -106,6 +114,7 @@ pub fn define(lib: &mut LibraryBuilder) -> BackTraced<()> {
         .method(update)?
         .method(execute)?
         .method(queue_error)?
+        .method(drop_next_add)?
         .async_method(add_async)?
         .custom_destroy("shutdown")?
         .doc("A class that manipulations integers on a Rust thread")?

--- a/tests/foo-schema/src/thread_class.rs
+++ b/tests/foo-schema/src/thread_class.rs
@@ -94,7 +94,6 @@ pub fn define(lib: &mut LibraryBuilder) -> BackTraced<()> {
         Primitive::U32,
         "result of the add operation",
         error_type,
-        "dropped",
     )?;
 
     let add_async = lib


### PR DESCRIPTION
1) Future-interfaces are now required to implement an error type. We didn't have a use case anyway for futures with no error.
2) The raw C interface now gets wrapped in a Promise type that ensures:
   A) The promise can only be completed once
   B) `Drop` is called with a specified error variant if promise is not completed by user code