### PR TITLE
Document C#/Java async methods properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,7 +481,7 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "oo-bindgen"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "backtrace",
  "clap",

--- a/oo-bindgen/src/backend/dotnet/class.rs
+++ b/oo-bindgen/src/backend/dotnet/class.rs
@@ -1,5 +1,6 @@
 use super::helpers::call_native_function;
 use super::*;
+use heck::ToUpperCamelCase;
 
 pub(crate) fn generate(
     f: &mut dyn Printer,
@@ -357,8 +358,23 @@ fn generate_async_method(
 
         // Print return value
         f.writeln("<returns>")?;
-        docstring_print(f, &method.future.value_type_doc)?;
-        f.write("</returns>")?;
+        indented(f, |f| {
+            f.writeln("<see cref=\"System.Threading.Tasks.Task\"/> containing: ")?;
+            docstring_print(f, &method.future.value_type_doc)?;
+            f.writeln("<para>")?;
+            indented(f, |f| {
+                f.writeln(&format!(
+                    "The returned Task may fail exceptionally with <see cref=\"{}\" />",
+                    method
+                        .future
+                        .error_type
+                        .exception_name
+                        .to_upper_camel_case()
+                ))
+            })?;
+            f.writeln("</para>")
+        })?;
+        f.writeln("</returns>")?;
 
         // Print exception
         if let Some(error) = &method.native_function.error_type.get() {

--- a/oo-bindgen/src/backend/java/api/class.rs
+++ b/oo-bindgen/src/backend/java/api/class.rs
@@ -1,5 +1,6 @@
 use super::doc::*;
 use super::*;
+use heck::ToUpperCamelCase;
 
 pub(crate) fn generate(
     f: &mut dyn Printer,
@@ -352,6 +353,19 @@ fn generate_async_method(
         // Print top-level documentation
         javadoc_print(f, &method.native_function.doc)?;
         f.newline()?;
+        f.writeln("<p>")?;
+        indented(f, |f| {
+            f.writeln(&format!(
+                "The returned stage may fail exceptionally with {{@link {}}}",
+                method
+                    .future
+                    .error_type
+                    .exception_name
+                    .to_upper_camel_case()
+            ))
+        })?;
+        f.writeln("</p>")?;
+        f.newline()?;
 
         // Print each parameter value
         for param in method.arguments_without_callback() {
@@ -360,7 +374,7 @@ fn generate_async_method(
         }
 
         // Print return value
-        f.writeln("@return ")?;
+        f.writeln("@return {@link java.util.concurrent.CompletionStage} containing: ")?;
         docstring_print(f, &method.future.value_type_doc)?;
 
         // Print exception

--- a/oo-bindgen/src/backend/java/api/mod.rs
+++ b/oo-bindgen/src/backend/java/api/mod.rs
@@ -218,7 +218,7 @@ fn generate_pom(lib: &Library, config: &JavaBindgenConfig) -> FormattingResult<(
         f.writeln("    <plugin>")?;
         f.writeln("      <groupId>org.apache.maven.plugins</groupId>")?;
         f.writeln("      <artifactId>maven-javadoc-plugin</artifactId>")?;
-        f.writeln("      <version>2.9.1</version>")?;
+        f.writeln("      <version>3.5.0</version>")?;
         f.writeln("      <executions>")?;
         f.writeln("        <execution>")?;
         f.writeln("        <id>attach-javadocs</id>")?;


### PR DESCRIPTION
1) Properly document that a `Task` or `CompletionStage` is the actual return type.

2) Document that the future type may fail exceptionally with a different exception than the method initiating the asynchronous request.