### PR TITLE
Generated docs for Java builder methods

### DIFF
--- a/oo-bindgen/src/backend/java/api/structure.rs
+++ b/oo-bindgen/src/backend/java/api/structure.rs
@@ -103,7 +103,7 @@ where
                     get_default_value_doc(&value.value)
                 ))?;
             }
-            f.writeln("</ul><p>")?;
+            f.writeln("</ul>")?;
         }
 
         f.newline()?;
@@ -282,8 +282,13 @@ where
         if st.visibility == Visibility::Public && generate_builder_methods {
             for field in st.fields() {
                 documentation(f, |f| {
-                    f.writeln(&format!("@param value New value for the '{}' field", field.name.mixed_case()))?;
-                    f.writeln("@return Reference to this instance of the class with the modified value")?;
+                    f.writeln(&format!(
+                        "@param value New value for the '{}' field",
+                        field.name.mixed_case()
+                    ))?;
+                    f.writeln(
+                        "@return Reference to this instance of the class with the modified value",
+                    )?;
                     Ok(())
                 })?;
 

--- a/oo-bindgen/src/backend/java/api/structure.rs
+++ b/oo-bindgen/src/backend/java/api/structure.rs
@@ -282,7 +282,8 @@ where
         if st.visibility == Visibility::Public && generate_builder_methods {
             for field in st.fields() {
                 documentation(f, |f| {
-                    javadoc_print(f, &field.doc)?;
+                    f.writeln(&format!("@param value New value for the '{}' field", field.name.mixed_case()))?;
+                    f.writeln("@return Reference to this instance of the class with the modified value")?;
                     Ok(())
                 })?;
 


### PR DESCRIPTION
Removes warning for missing docs on the structure building helper methods (`with<FieldName>`).