### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/oo-bindgen/Cargo.toml
+++ b/oo-bindgen/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Step Function I/O LLC <info@stepfunc.io>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "DSL-based binding geneator for C, C++, Java, and C#"
-homepage = "https://github.com/stepfunc/oo_bindgen/"
+repository = "https://github.com/stepfunc/oo_bindgen/"
 readme = "../README.md"
 
 [dependencies]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.